### PR TITLE
Fix a bug in pull schema and write the schema to .gql or .graphql files if set in config.

### DIFF
--- a/example/schema/schema.gql
+++ b/example/schema/schema.gql
@@ -1,49 +1,59 @@
-type Error {
-	message: String!
-	code: String!
-}
-
-type TodoItem {
-	id: ID!
-	text: String!
-	completed: Boolean!
-}
-
-type Query {
-	items(completed: Boolean): [TodoItem!]!
-}
-
-type Mutation {
-	checkItem(item: ID!): UpdateItemOutput!
-	uncheckItem(item: ID!): UpdateItemOutput!
-	addItem(input: AddItemInput!): AddItemOutput!
-	deleteItem(item: ID!): DeleteIemOutput!
-}
-
-type Subscription {
-	itemUpdate(id: ID!): ItemUpdate!
-	newItem: ItemUpdate!
-}
+directive @cacheControl(maxAge: Int, scope: CacheControlScope) on FIELD_DEFINITION | INTERFACE | OBJECT
 
 input AddItemInput {
-	text: String!
+  text: String!
 }
 
 type AddItemOutput {
-	error: Error
-	item: TodoItem
+  error: Error
+  item: TodoItem
 }
 
-type UpdateItemOutput {
-	error: Error
-	item: TodoItem
+enum CacheControlScope {
+  PRIVATE
+  PUBLIC
 }
 
 type DeleteIemOutput {
-	error: Error
-	itemID: ID
+  error: Error
+  itemID: ID
+}
+
+type Error {
+  code: String!
+  message: String!
 }
 
 type ItemUpdate {
-	item: TodoItem!
+  item: TodoItem!
 }
+
+type Mutation {
+  addItem(input: AddItemInput!): AddItemOutput!
+  checkItem(item: ID!): UpdateItemOutput!
+  deleteItem(item: ID!): DeleteIemOutput!
+  uncheckItem(item: ID!): UpdateItemOutput!
+}
+
+type Query {
+  items(completed: Boolean): [TodoItem!]!
+}
+
+type Subscription {
+  itemUpdate(id: ID!): ItemUpdate!
+  newItem: ItemUpdate!
+}
+
+type TodoItem {
+  completed: Boolean!
+  id: ID!
+  text: String!
+}
+
+type UpdateItemOutput {
+  error: Error
+  item: TodoItem
+}
+
+"""The `Upload` scalar type represents a file upload."""
+scalar Upload

--- a/packages/houdini/cmd/main.ts
+++ b/packages/houdini/cmd/main.ts
@@ -4,6 +4,7 @@
 import { getConfig } from 'houdini-common'
 import { Command } from 'commander'
 import path from 'path'
+import * as graphql from 'graphql'
 // local imports
 import compile from './compile'
 import init from './init'
@@ -33,10 +34,12 @@ program
 				// The target path -> current working directory by default. Should we allow passing custom paths?
 				const targetPath = process.cwd()
 				// Write the schema
-				await writeSchema(
+				const schema = await writeSchema(
 					config.apiUrl,
 					config.schemaPath ? config.schemaPath : path.resolve(targetPath, 'schema.json')
 				)
+				// Set the newly written schema into the config
+				config.schema = schema;
 			}
 			await compile(config)
 		} catch (e) {


### PR DESCRIPTION
I noticed that with the current implementation of pull-schema, you have to execute the command twice because the config reads the schema before it gets updated.
I've also updated the writeSchema function to write .gql/.graphql files correctly since the current behaviour writes json into it.