### PR TITLE
Remove check for mutation rootType

### DIFF
--- a/packages/houdini-preprocess/src/transforms/mutation.ts
+++ b/packages/houdini-preprocess/src/transforms/mutation.ts
@@ -16,12 +16,6 @@ export default async function mutationProcessor(
 		return
 	}
 
-	// figure out the root type
-	const rootType = doc.config.schema.getMutationType()
-	if (!rootType) {
-		throw new Error('Could not find operation type')
-	}
-
 	// go to every graphql document
 	await walkTaggedDocuments(config, doc, doc.instance.content, {
 		// with only one definition defining a fragment


### PR DESCRIPTION
This PR fixes #98 and removes the check for a mutation root type. The value wasn't used anywhere and was left overs from an old implementation of the preprocessor. 