### PR TITLE
Better parser

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "example-kit",
 	"private": true,
-	"version": "0.7.2-rc.1",
+	"version": "0.7.2-rc.2",
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",
@@ -12,8 +12,8 @@
 	"devDependencies": {
 		"@sveltejs/kit": "1.0.0-next.107",
 		"graphql": "15.5.0",
-		"houdini": "^0.7.2-rc.1",
-		"houdini-preprocess": "^0.7.2-rc.1",
+		"houdini": "^0.7.2-rc.2",
+		"houdini-preprocess": "^0.7.2-rc.2",
 		"svelte": "^3.38.2",
 		"svelte-preprocess": "^4.0.0",
 		"tslib": "^2.2.0",

--- a/example/package.json
+++ b/example/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "example-kit",
 	"private": true,
-	"version": "0.7.2-rc.3",
+	"version": "0.7.2-rc.4",
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",
@@ -12,8 +12,8 @@
 	"devDependencies": {
 		"@sveltejs/kit": "1.0.0-next.107",
 		"graphql": "15.5.0",
-		"houdini": "^0.7.2-rc.3",
-		"houdini-preprocess": "^0.7.2-rc.3",
+		"houdini": "^0.7.2-rc.4",
+		"houdini-preprocess": "^0.7.2-rc.4",
 		"svelte": "^3.38.2",
 		"svelte-preprocess": "^4.0.0",
 		"tslib": "^2.2.0",

--- a/example/package.json
+++ b/example/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "example-kit",
 	"private": true,
-	"version": "0.7.1",
+	"version": "0.7.2-rc.0",
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",
@@ -12,8 +12,8 @@
 	"devDependencies": {
 		"@sveltejs/kit": "1.0.0-next.107",
 		"graphql": "15.5.0",
-		"houdini": "^0.7.1",
-		"houdini-preprocess": "^0.7.1",
+		"houdini": "^0.7.2-rc.0",
+		"houdini-preprocess": "^0.7.2-rc.0",
 		"svelte": "^3.38.2",
 		"svelte-preprocess": "^4.0.0",
 		"tslib": "^2.2.0",

--- a/example/package.json
+++ b/example/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "example-kit",
 	"private": true,
-	"version": "0.7.2-rc.0",
+	"version": "0.7.2-rc.1",
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",
@@ -12,8 +12,8 @@
 	"devDependencies": {
 		"@sveltejs/kit": "1.0.0-next.107",
 		"graphql": "15.5.0",
-		"houdini": "^0.7.2-rc.0",
-		"houdini-preprocess": "^0.7.2-rc.0",
+		"houdini": "^0.7.2-rc.1",
+		"houdini-preprocess": "^0.7.2-rc.1",
 		"svelte": "^3.38.2",
 		"svelte-preprocess": "^4.0.0",
 		"tslib": "^2.2.0",

--- a/example/package.json
+++ b/example/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "example-kit",
 	"private": true,
-	"version": "0.7.2-rc.2",
+	"version": "0.7.2-rc.3",
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",
@@ -12,8 +12,8 @@
 	"devDependencies": {
 		"@sveltejs/kit": "1.0.0-next.107",
 		"graphql": "15.5.0",
-		"houdini": "^0.7.2-rc.2",
-		"houdini-preprocess": "^0.7.2-rc.2",
+		"houdini": "^0.7.2-rc.3",
+		"houdini-preprocess": "^0.7.2-rc.3",
 		"svelte": "^3.38.2",
 		"svelte-preprocess": "^4.0.0",
 		"tslib": "^2.2.0",

--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
 		"packages/*",
 		"example"
 	],
-	"version": "0.7.2-rc.3",
+	"version": "0.7.2-rc.4",
 	"npmClient": "yarn"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
 		"packages/*",
 		"example"
 	],
-	"version": "0.7.1",
+	"version": "0.7.2-rc.0",
 	"npmClient": "yarn"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
 		"packages/*",
 		"example"
 	],
-	"version": "0.7.2-rc.0",
+	"version": "0.7.2-rc.1",
 	"npmClient": "yarn"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
 		"packages/*",
 		"example"
 	],
-	"version": "0.7.2-rc.2",
+	"version": "0.7.2-rc.3",
 	"npmClient": "yarn"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
 		"packages/*",
 		"example"
 	],
-	"version": "0.7.2-rc.1",
+	"version": "0.7.2-rc.2",
 	"npmClient": "yarn"
 }

--- a/packages/houdini-common/package.json
+++ b/packages/houdini-common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini-common",
-	"version": "0.7.2-rc.2",
+	"version": "0.7.2-rc.3",
 	"description": "",
 	"main": "build/cjs/index.js",
 	"module": "build/esm/index.js",

--- a/packages/houdini-common/package.json
+++ b/packages/houdini-common/package.json
@@ -13,7 +13,8 @@
 	"scripts": {
 		"build": "npm run build:esm && npm run build:cjs && ../houdini-preprocess/typeModules.sh",
 		"build:esm": "TARGET=esm rollup --config ./rollup.config.js",
-		"build:cjs": "TARGET=cjs rollup --config ./rollup.config.js"
+		"build:cjs": "TARGET=cjs rollup --config ./rollup.config.js",
+		"prepare": "npm run build"
 	},
 	"keywords": [],
 	"author": "",

--- a/packages/houdini-common/package.json
+++ b/packages/houdini-common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini-common",
-	"version": "0.7.2-rc.3",
+	"version": "0.7.2-rc.4",
 	"description": "",
 	"main": "build/cjs/index.js",
 	"module": "build/esm/index.js",

--- a/packages/houdini-common/package.json
+++ b/packages/houdini-common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini-common",
-	"version": "0.7.0",
+	"version": "0.7.2-rc.0",
 	"description": "",
 	"main": "build/cjs/index.js",
 	"module": "build/esm/index.js",

--- a/packages/houdini-common/package.json
+++ b/packages/houdini-common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini-common",
-	"version": "0.7.2-rc.0",
+	"version": "0.7.2-rc.1",
 	"description": "",
 	"main": "build/cjs/index.js",
 	"module": "build/esm/index.js",

--- a/packages/houdini-common/package.json
+++ b/packages/houdini-common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini-common",
-	"version": "0.7.2-rc.1",
+	"version": "0.7.2-rc.2",
 	"description": "",
 	"main": "build/cjs/index.js",
 	"module": "build/esm/index.js",

--- a/packages/houdini-common/src/parse.test.ts
+++ b/packages/houdini-common/src/parse.test.ts
@@ -193,6 +193,29 @@ describe('parser tests', () => {
 		expect(result.module?.end).toMatchInlineSnapshot(`84`)
 	})
 
+	test('comments', () => {
+		// parse the string
+		const result = parseFile(`
+            <!-- <script context='module'> -->
+			<script>
+				console.log('hello')
+            </script>
+			{#if foo < 2}
+				<div>
+					hello
+				</div>
+			{/if}
+        `)
+
+		expect(result.instance?.content).toMatchInlineSnapshot(`console.log("hello");`)
+		expect(result.instance?.start).toMatchInlineSnapshot(`51`)
+		expect(result.instance?.end).toMatchInlineSnapshot(`105`)
+
+		expect(result.module?.content).toMatchInlineSnapshot(`undefined`)
+		expect(result.module?.start).toMatchInlineSnapshot(`undefined`)
+		expect(result.module?.end).toMatchInlineSnapshot(`undefined`)
+	})
+
 	test("else in template doesn't break things", () => {
 		// parse the string
 		const result = parseFile(`

--- a/packages/houdini-common/src/parse.test.ts
+++ b/packages/houdini-common/src/parse.test.ts
@@ -241,4 +241,50 @@ describe('parser tests', () => {
 		expect(result.module?.start).toMatchInlineSnapshot(`13`)
 		expect(result.module?.end).toMatchInlineSnapshot(`84`)
 	})
+
+	test('expression in content', () => {
+		// parse the string
+		const result = parseFile(`
+            <script context='module'>
+				console.log('hello')
+            </script>
+			<div>
+				{hello}
+			</div>
+        `)
+
+		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
+		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
+		expect(result.instance?.end).toMatchInlineSnapshot(`undefined`)
+
+		expect(result.module?.content).toMatchInlineSnapshot(`console.log("hello");`)
+		expect(result.module?.start).toMatchInlineSnapshot(`13`)
+		expect(result.module?.end).toMatchInlineSnapshot(`84`)
+	})
+
+	test('expression attribute', () => {
+		// parse the string
+		const result = parseFile(`
+            <script context='module'>
+				console.log('hello')
+            </script>
+			{#if foo < 2}
+				<div>
+					hello
+				</div>
+			{:else if foo < 4}
+				<div attribute={{foo}}>
+					hello
+				</div>
+			{/if}
+        `)
+
+		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
+		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
+		expect(result.instance?.end).toMatchInlineSnapshot(`undefined`)
+
+		expect(result.module?.content).toMatchInlineSnapshot(`console.log("hello");`)
+		expect(result.module?.start).toMatchInlineSnapshot(`13`)
+		expect(result.module?.end).toMatchInlineSnapshot(`84`)
+	})
 })

--- a/packages/houdini-common/src/parse.test.ts
+++ b/packages/houdini-common/src/parse.test.ts
@@ -405,6 +405,28 @@ describe('parser tests', () => {
 
 		checkScriptBounds(doc, result)
 	})
+
+	test('empty object in script', () => {
+		const doc = `<script lang="ts">
+		const example = object({});
+	</script>
+	 
+	<div>hello</div>
+	`
+
+		// parse the string
+		const result = parseFile(doc)
+
+		expect(result.instance?.content).toMatchInlineSnapshot(`const example = object({});`)
+		expect(result.instance?.start).toMatchInlineSnapshot(`0`)
+		expect(result.instance?.end).toMatchInlineSnapshot(`58`)
+
+		expect(result.module?.content).toMatchInlineSnapshot(`undefined`)
+		expect(result.module?.start).toMatchInlineSnapshot(`undefined`)
+		expect(result.module?.end).toMatchInlineSnapshot(`undefined`)
+
+		checkScriptBounds(doc, result)
+	})
 })
 
 function checkScriptBounds(doc: string, result?: ParsedSvelteFile | null | undefined) {

--- a/packages/houdini-common/src/parse.test.ts
+++ b/packages/houdini-common/src/parse.test.ts
@@ -158,4 +158,30 @@ describe('parser tests', () => {
 		expect(result.module?.start).toMatchInlineSnapshot(`13`)
 		expect(result.module?.end).toMatchInlineSnapshot(`84`)
 	})
+
+	test("logic in template doesn't break things", () => {
+		// parse the string
+		const result = parseFile(`
+            <script context='module'>
+				console.log('hello')
+            </script>
+			{#if foo < 2}
+				<div>
+					hello
+				</div>
+			{:else if foo < 4}
+				<div>
+					hello
+				</div>
+			{/if}
+        `)
+
+		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
+		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
+		expect(result.instance?.end).toMatchInlineSnapshot(`undefined`)
+
+		expect(result.module?.content).toMatchInlineSnapshot(`console.log("hello");`)
+		expect(result.module?.start).toMatchInlineSnapshot(`13`)
+		expect(result.module?.end).toMatchInlineSnapshot(`84`)
+	})
 })

--- a/packages/houdini-common/src/parse.test.ts
+++ b/packages/houdini-common/src/parse.test.ts
@@ -453,9 +453,7 @@ describe('parser tests', () => {
 								/>
 							</svg>
 						</button>
-						<div
-							class="h-32 w-64 bg-gray-50 dark:bg-gray-800 mt-1 shadow rounded-md"
-						/>
+						<div class="h-32 w-64 bg-gray-50 dark:bg-gray-800 mt-1 shadow rounded-md" />
 					</Menu>
 					<Menu>
 						<button

--- a/packages/houdini-common/src/parse.test.ts
+++ b/packages/houdini-common/src/parse.test.ts
@@ -113,4 +113,45 @@ describe('parser tests', () => {
 		expect(result.module?.start).toMatchInlineSnapshot(`undefined`)
 		expect(result.module?.end).toMatchInlineSnapshot(`undefined`)
 	})
+
+	test("logic in script doesn't break things", () => {
+		// parse the string
+		const result = parseFile(`
+            <script context='module'>
+				if (1<2) {
+					console.log('hello')
+				}
+            </script>
+        `)
+
+		expect(result.instance?.content).toMatchInlineSnapshot()
+		expect(result.instance?.start).toMatchInlineSnapshot()
+		expect(result.instance?.end).toMatchInlineSnapshot()
+
+		expect(result.module?.content).toMatchInlineSnapshot()
+		expect(result.module?.start).toMatchInlineSnapshot()
+		expect(result.module?.end).toMatchInlineSnapshot()
+	})
+
+	test("logic in template doesn't break things", () => {
+		// parse the string
+		const result = parseFile(`
+            <script context='module'>
+				console.log('hello')
+            </script>
+			{#if foo < 2}
+				<div>
+					hello
+				</div>
+			{/if}
+        `)
+
+		expect(result.instance?.content).toMatchInlineSnapshot()
+		expect(result.instance?.start).toMatchInlineSnapshot()
+		expect(result.instance?.end).toMatchInlineSnapshot()
+
+		expect(result.module?.content).toMatchInlineSnapshot()
+		expect(result.module?.start).toMatchInlineSnapshot()
+		expect(result.module?.end).toMatchInlineSnapshot()
+	})
 })

--- a/packages/houdini-common/src/parse.test.ts
+++ b/packages/houdini-common/src/parse.test.ts
@@ -369,6 +369,183 @@ describe('parser tests', () => {
 
 		checkScriptBounds(doc, result)
 	})
+
+	test('pixelmund 1', () => {
+		const doc = `<script lang="ts">
+			import Menu from './Menu.svelte';
+		
+			import { session } from '$app/stores';
+		
+			import { graphql, Logout, mutation, ToggleTheme } from '$houdini';
+			import MenuItem from './MenuItem.svelte';
+		
+			const toggleTheme = mutation<ToggleTheme>(graphql\`
+				mutation ToggleTheme {
+					toggleTheme
+				}
+			\`);
+		
+			const logout = mutation<Logout>(graphql\`
+				mutation Logout {
+					logout {
+						ok
+					}
+				}
+			\`);
+		
+			async function signOut() {
+				const result = await logout(null);
+				window.location.reload();
+			}
+		
+			async function changeTheme() {
+				const response = await toggleTheme(null);
+				document.documentElement.classList.remove('dark', 'light');
+				document.documentElement.classList.add(response.toggleTheme);
+				session.update((cur) => ({
+					...cur,
+					session: {
+						...cur.session,
+						external: {
+							...cur.session.external,
+							darkmode: response.toggleTheme === 'dark',
+						},
+					},
+				}));
+			}
+		
+		</script>
+		
+		<header
+			class="sticky flex items-center justify-between h-16 top-0 inset-x-0 max-w-7xl px-2 xl:px-0 mx-auto"
+		>
+			<a href="/">
+				<div class="font-bold italic text-lg">noods</div>
+			</a>
+			<nav>
+				<ul>
+					<li />
+				</ul>
+			</nav>
+			<div class="flex items-center space-x-4">
+				{#if $session?.user}
+					<Menu>
+						<button
+							slot="trigger"
+							let:trigger
+							let:active
+							on:click={trigger}
+							class="focus:outline-none focus:text-brand-400 {active
+								? 'text-brand-500'
+								: 'text-gray-400'}"
+						>
+							<svg
+								class="w-6 h-6"
+								fill="none"
+								stroke="currentColor"
+								viewBox="0 0 24 24"
+								xmlns="http://www.w3.org/2000/svg"
+								><path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width="2"
+									d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+								/>
+							</svg>
+						</button>
+						<div
+							class="h-32 w-64 bg-gray-50 dark:bg-gray-800 mt-1 shadow rounded-md"
+						/>
+					</Menu>
+					<Menu>
+						<button
+							slot="trigger"
+							let:trigger
+							let:active
+							on:click={trigger}
+							class="focus:outline-none group {active
+								? 'text-brand-500'
+								: 'text-gray-400'}"
+						>
+							<img
+								class="rounded-full w-10 h-10 object-cover border-2 border-transparent transition group-focus:border-brand-400 {active
+									? 'border-brand-500'
+									: ''}"
+								src={$session?.user?.avatar ??
+									'https://images.unsplash.com/photo-1543610892-0b1f7e6d8ac1?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=150&q=80'}
+								alt={$session?.user?.username}
+							/>
+						</button>
+						<div
+							class="h-32 w-48 bg-gray-50 dark:bg-gray-800 mt-1 shadow rounded-md space-y-1"
+						>
+							<MenuItem tag="button" on:click={changeTheme}>Toggle Theme</MenuItem>
+							<MenuItem tag="button" on:click={signOut}>Sign out</MenuItem>
+						</div>
+					</Menu>
+				{:else}
+					<a href="/auth/sign-in">Sign in</a>
+				{/if}
+			</div>
+		</header>
+	`
+
+		// parse the string
+		const result = parseFile(doc)
+
+		expect(result.instance?.content).toMatchInlineSnapshot(`
+		import Menu from "./Menu.svelte";
+		import { session } from "$app/stores";
+		import { graphql, Logout, mutation, ToggleTheme } from "$houdini";
+		import MenuItem from "./MenuItem.svelte";
+
+		const toggleTheme = mutation<ToggleTheme>(graphql\`
+						mutation ToggleTheme {
+							toggleTheme
+						}
+					\`);
+
+		const logout = mutation<Logout>(graphql\`
+						mutation Logout {
+							logout {
+								ok
+							}
+						}
+					\`);
+
+		async function signOut() {
+		    const result = await logout(null);
+		    window.location.reload();
+		}
+
+		async function changeTheme() {
+		    const response = await toggleTheme(null);
+		    document.documentElement.classList.remove("dark", "light");
+		    document.documentElement.classList.add(response.toggleTheme);
+
+		    session.update(cur => ({
+		        ...cur,
+
+		        session: {
+		            ...cur.session,
+
+		            external: {
+		                ...cur.session.external,
+		                darkmode: response.toggleTheme === "dark"
+		            }
+		        }
+		    }));
+		}
+	`)
+		expect(result.instance?.start).toMatchInlineSnapshot(`0`)
+		expect(result.instance?.end).toMatchInlineSnapshot(`991`)
+
+		expect(result.module?.content).toMatchInlineSnapshot(`undefined`)
+		expect(result.module?.start).toMatchInlineSnapshot(`undefined`)
+		expect(result.module?.end).toMatchInlineSnapshot(`undefined`)
+
+		checkScriptBounds(doc, result)
+	})
 })
 
 function checkScriptBounds(doc: string, result?: ParsedSvelteFile | null | undefined) {

--- a/packages/houdini-common/src/parse.test.ts
+++ b/packages/houdini-common/src/parse.test.ts
@@ -370,173 +370,34 @@ describe('parser tests', () => {
 		checkScriptBounds(doc, result)
 	})
 
-	test('pixelmund 1', () => {
+	test('tabs to end tags', () => {
 		const doc = `<script lang="ts">
-			import Menu from './Menu.svelte';
-		
-			import { session } from '$app/stores';
-		
-			import { graphql, Logout, mutation, ToggleTheme } from '$houdini';
-			import MenuItem from './MenuItem.svelte';
-		
-			const toggleTheme = mutation<ToggleTheme>(graphql\`
-				mutation ToggleTheme {
-					toggleTheme
-				}
-			\`);
-		
-			const logout = mutation<Logout>(graphql\`
-				mutation Logout {
-					logout {
-						ok
-					}
-				}
-			\`);
-		
-			async function signOut() {
-				const result = await logout(null);
-				window.location.reload();
-			}
-		
-			async function changeTheme() {
-				const response = await toggleTheme(null);
-				document.documentElement.classList.remove('dark', 'light');
-				document.documentElement.classList.add(response.toggleTheme);
-				session.update((cur) => ({
-					...cur,
-					session: {
-						...cur.session,
-						external: {
-							...cur.session.external,
-							darkmode: response.toggleTheme === 'dark',
-						},
-					},
-				}));
-			}
-		
+			console.log('hello')
 		</script>
 		
 		<header
 			class="sticky flex items-center justify-between h-16 top-0 inset-x-0 max-w-7xl px-2 xl:px-0 mx-auto"
 		>
-			<a href="/">
-				<div class="font-bold italic text-lg">noods</div>
-			</a>
-			<nav>
-				<ul>
-					<li />
-				</ul>
-			</nav>
-			<div class="flex items-center space-x-4">
-				{#if $session?.user}
-					<Menu>
-						<button
-							slot="trigger"
-							let:trigger
-							let:active
-							on:click={trigger}
-							class="focus:outline-none focus:text-brand-400 {active
-								? 'text-brand-500'
-								: 'text-gray-400'}"
-						>
-							<svg
-								class="w-6 h-6"
-								fill="none"
-								stroke="currentColor"
-								viewBox="0 0 24 24"
-								xmlns="http://www.w3.org/2000/svg"
-								><path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="2"
-									d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
-								/>
-							</svg>
-						</button>
-						<div class="h-32 w-64 bg-gray-50 dark:bg-gray-800 mt-1 shadow rounded-md" />
-					</Menu>
-					<Menu>
-						<button
-							slot="trigger"
-							let:trigger
-							let:active
-							on:click={trigger}
-							class="focus:outline-none group {active
-								? 'text-brand-500'
-								: 'text-gray-400'}"
-						>
-							<img
-								class="rounded-full w-10 h-10 object-cover border-2 border-transparent transition group-focus:border-brand-400 {active
-									? 'border-brand-500'
-									: ''}"
-								src={$session?.user?.avatar ??
-									'https://images.unsplash.com/photo-1543610892-0b1f7e6d8ac1?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=150&q=80'}
-								alt={$session?.user?.username}
-							/>
-						</button>
-						<div
-							class="h-32 w-48 bg-gray-50 dark:bg-gray-800 mt-1 shadow rounded-md space-y-1"
-						>
-							<MenuItem tag="button" on:click={changeTheme}>Toggle Theme</MenuItem>
-							<MenuItem tag="button" on:click={signOut}>Sign out</MenuItem>
-						</div>
-					</Menu>
-				{:else}
-					<a href="/auth/sign-in">Sign in</a>
-				{/if}
-			</div>
+			
+			<svg
+			class="w-6 h-6"
+			fill="none"
+			stroke="currentColor"
+			viewBox="0 0 24 24"
+			xmlns="http://www.w3.org/2000/svg"
+			><path
+			/>
+				hello
+			</svg>
 		</header>
 	`
 
 		// parse the string
 		const result = parseFile(doc)
 
-		expect(result.instance?.content).toMatchInlineSnapshot(`
-		import Menu from "./Menu.svelte";
-		import { session } from "$app/stores";
-		import { graphql, Logout, mutation, ToggleTheme } from "$houdini";
-		import MenuItem from "./MenuItem.svelte";
-
-		const toggleTheme = mutation<ToggleTheme>(graphql\`
-						mutation ToggleTheme {
-							toggleTheme
-						}
-					\`);
-
-		const logout = mutation<Logout>(graphql\`
-						mutation Logout {
-							logout {
-								ok
-							}
-						}
-					\`);
-
-		async function signOut() {
-		    const result = await logout(null);
-		    window.location.reload();
-		}
-
-		async function changeTheme() {
-		    const response = await toggleTheme(null);
-		    document.documentElement.classList.remove("dark", "light");
-		    document.documentElement.classList.add(response.toggleTheme);
-
-		    session.update(cur => ({
-		        ...cur,
-
-		        session: {
-		            ...cur.session,
-
-		            external: {
-		                ...cur.session.external,
-		                darkmode: response.toggleTheme === "dark"
-		            }
-		        }
-		    }));
-		}
-	`)
+		expect(result.instance?.content).toMatchInlineSnapshot(`console.log("hello");`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`0`)
-		expect(result.instance?.end).toMatchInlineSnapshot(`991`)
+		expect(result.instance?.end).toMatchInlineSnapshot(`53`)
 
 		expect(result.module?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.module?.start).toMatchInlineSnapshot(`undefined`)

--- a/packages/houdini-common/src/parse.test.ts
+++ b/packages/houdini-common/src/parse.test.ts
@@ -427,6 +427,25 @@ describe('parser tests', () => {
 
 		checkScriptBounds(doc, result)
 	})
+
+	test('empty expression', () => {
+		const doc = `
+	<div foo={}>hello</div>
+	`
+
+		// parse the string
+		const result = parseFile(doc)
+
+		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
+		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
+		expect(result.instance?.end).toMatchInlineSnapshot(`undefined`)
+
+		expect(result.module?.content).toMatchInlineSnapshot(`undefined`)
+		expect(result.module?.start).toMatchInlineSnapshot(`undefined`)
+		expect(result.module?.end).toMatchInlineSnapshot(`undefined`)
+
+		checkScriptBounds(doc, result)
+	})
 })
 
 function checkScriptBounds(doc: string, result?: ParsedSvelteFile | null | undefined) {

--- a/packages/houdini-common/src/parse.test.ts
+++ b/packages/houdini-common/src/parse.test.ts
@@ -15,8 +15,12 @@ describe('parser tests', () => {
         `)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`console.log("instance");`)
+		expect(result.instance?.start).toMatchInlineSnapshot(`112`)
+		expect(result.instance?.end).toMatchInlineSnapshot(`181`)
 
 		expect(result.module?.content).toMatchInlineSnapshot(`console.log("module");`)
+		expect(result.module?.start).toMatchInlineSnapshot(`13`)
+		expect(result.module?.end).toMatchInlineSnapshot(`97`)
 	})
 
 	test('happy path - only module', () => {
@@ -28,21 +32,29 @@ describe('parser tests', () => {
         `)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
+		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
+		expect(result.instance?.end).toMatchInlineSnapshot(`undefined`)
 
 		expect(result.module?.content).toMatchInlineSnapshot(`console.log("module");`)
+		expect(result.module?.start).toMatchInlineSnapshot(`13`)
+		expect(result.module?.end).toMatchInlineSnapshot(`97`)
 	})
 
 	test('happy path - only instance', () => {
 		// parse the string
 		const result = parseFile(`
-            <script context="module">
+            <script>
                 console.log('module')
             </script>
         `)
 
-		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
+		expect(result.instance?.content).toMatchInlineSnapshot(`console.log("module");`)
+		expect(result.instance?.start).toMatchInlineSnapshot(`13`)
+		expect(result.instance?.end).toMatchInlineSnapshot(`80`)
 
-		expect(result.module?.content).toMatchInlineSnapshot(`console.log("module");`)
+		expect(result.module?.content).toMatchInlineSnapshot(`undefined`)
+		expect(result.module?.start).toMatchInlineSnapshot(`undefined`)
+		expect(result.module?.end).toMatchInlineSnapshot(`undefined`)
 	})
 
 	test('single quotes', () => {
@@ -54,20 +66,51 @@ describe('parser tests', () => {
         `)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
+		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
+		expect(result.instance?.end).toMatchInlineSnapshot(`undefined`)
 
 		expect(result.module?.content).toMatchInlineSnapshot(`console.log("module");`)
+		expect(result.module?.start).toMatchInlineSnapshot(`13`)
+		expect(result.module?.end).toMatchInlineSnapshot(`97`)
 	})
 
 	test('happy path - typescript', () => {
 		// parse the string
 		const result = parseFile(`
             <script context="module" lang="ts">
-                console.log('module')
+				type Foo = { hello: string}
             </script>
         `)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
+		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
+		expect(result.instance?.end).toMatchInlineSnapshot(`undefined`)
 
-		expect(result.module?.content).toMatchInlineSnapshot(`console.log("module");`)
+		expect(result.module?.content).toMatchInlineSnapshot(`
+		type Foo = {
+		    hello: string
+		};
+	`)
+		expect(result.module?.start).toMatchInlineSnapshot(`13`)
+		expect(result.module?.end).toMatchInlineSnapshot(`101`)
+	})
+
+	test('nested script block', () => {
+		// parse the string
+		const result = parseFile(`
+	        <div>
+				<script>
+					console.log('inner')
+				</script>
+	        </div>
+	    `)
+
+		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
+		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
+		expect(result.instance?.end).toMatchInlineSnapshot(`undefined`)
+
+		expect(result.module?.content).toMatchInlineSnapshot(`undefined`)
+		expect(result.module?.start).toMatchInlineSnapshot(`undefined`)
+		expect(result.module?.end).toMatchInlineSnapshot(`undefined`)
 	})
 })

--- a/packages/houdini-common/src/parse.test.ts
+++ b/packages/houdini-common/src/parse.test.ts
@@ -341,8 +341,8 @@ describe('parser tests', () => {
 					hello
 				</div>
 			{:else if foo < 4}
-				<!-- 
-					the crazy <div is to trick the parser into thinking there's 
+				<!--
+					the crazy <div is to trick the parser into thinking there's
 					a new tag inside of an expression
 				-->
 				<div attribute={foo > && <div 2} foo>
@@ -364,8 +364,8 @@ describe('parser tests', () => {
 		expect(result.instance?.end).toMatchInlineSnapshot(`undefined`)
 
 		expect(result.module?.content).toMatchInlineSnapshot(`console.log("hello");`)
-		expect(result.module?.start).toMatchInlineSnapshot(`306`)
-		expect(result.module?.end).toMatchInlineSnapshot(`368`)
+		expect(result.module?.start).toMatchInlineSnapshot(`304`)
+		expect(result.module?.end).toMatchInlineSnapshot(`366`)
 
 		checkScriptBounds(doc, result)
 	})
@@ -374,11 +374,11 @@ describe('parser tests', () => {
 		const doc = `<script lang="ts">
 			console.log('hello')
 		</script>
-		
+
 		<header
 			class="sticky flex items-center justify-between h-16 top-0 inset-x-0 max-w-7xl px-2 xl:px-0 mx-auto"
 		>
-			
+
 			<svg
 			class="w-6 h-6"
 			fill="none"
@@ -410,7 +410,7 @@ describe('parser tests', () => {
 		const doc = `<script lang="ts">
 		const example = object({});
 	</script>
-	 
+
 	<div>hello</div>
 	`
 
@@ -445,6 +445,20 @@ describe('parser tests', () => {
 		expect(result.module?.end).toMatchInlineSnapshot(`undefined`)
 
 		checkScriptBounds(doc, result)
+	})
+
+	test('error messages include line number', () => {
+		try {
+			// parse the string
+			parseFile(`
+				<div`)
+
+			fail('no error thrown')
+		} catch (e) {
+			const message = (e as Error).message
+
+			expect(message).toContain('line 2')
+		}
 	})
 })
 

--- a/packages/houdini-common/src/parse.test.ts
+++ b/packages/houdini-common/src/parse.test.ts
@@ -23,6 +23,21 @@ describe('parser tests', () => {
 		expect(result.module?.end).toMatchInlineSnapshot(`97`)
 	})
 
+	test('happy path - start on first character', () => {
+		// parse the string
+		const result = parseFile(`<script context="module">
+                console.log('module')
+            </script>`)
+
+		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
+		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
+		expect(result.instance?.end).toMatchInlineSnapshot(`undefined`)
+
+		expect(result.module?.content).toMatchInlineSnapshot(`console.log("module");`)
+		expect(result.module?.start).toMatchInlineSnapshot(`0`)
+		expect(result.module?.end).toMatchInlineSnapshot(`84`)
+	})
+
 	test('happy path - only module', () => {
 		// parse the string
 		const result = parseFile(`
@@ -108,6 +123,25 @@ describe('parser tests', () => {
 		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.end).toMatchInlineSnapshot(`undefined`)
+
+		expect(result.module?.content).toMatchInlineSnapshot(`undefined`)
+		expect(result.module?.start).toMatchInlineSnapshot(`undefined`)
+		expect(result.module?.end).toMatchInlineSnapshot(`undefined`)
+	})
+
+	test('script next to html', () => {
+		// parse the string
+		const result = parseFile(`
+			<script>
+				console.log('script')
+			</script>
+	        <div>
+	        </div>
+	    `)
+
+		expect(result.instance?.content).toMatchInlineSnapshot(`console.log("script");`)
+		expect(result.instance?.start).toMatchInlineSnapshot(`4`)
+		expect(result.instance?.end).toMatchInlineSnapshot(`50`)
 
 		expect(result.module?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.module?.start).toMatchInlineSnapshot(`undefined`)

--- a/packages/houdini-common/src/parse.test.ts
+++ b/packages/houdini-common/src/parse.test.ts
@@ -124,13 +124,17 @@ describe('parser tests', () => {
             </script>
         `)
 
-		expect(result.instance?.content).toMatchInlineSnapshot()
-		expect(result.instance?.start).toMatchInlineSnapshot()
-		expect(result.instance?.end).toMatchInlineSnapshot()
+		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
+		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
+		expect(result.instance?.end).toMatchInlineSnapshot(`undefined`)
 
-		expect(result.module?.content).toMatchInlineSnapshot()
-		expect(result.module?.start).toMatchInlineSnapshot()
-		expect(result.module?.end).toMatchInlineSnapshot()
+		expect(result.module?.content).toMatchInlineSnapshot(`
+		if (1 < 2) {
+		    console.log("hello");
+		}
+	`)
+		expect(result.module?.start).toMatchInlineSnapshot(`13`)
+		expect(result.module?.end).toMatchInlineSnapshot(`106`)
 	})
 
 	test("logic in template doesn't break things", () => {
@@ -146,12 +150,12 @@ describe('parser tests', () => {
 			{/if}
         `)
 
-		expect(result.instance?.content).toMatchInlineSnapshot()
-		expect(result.instance?.start).toMatchInlineSnapshot()
-		expect(result.instance?.end).toMatchInlineSnapshot()
+		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
+		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
+		expect(result.instance?.end).toMatchInlineSnapshot(`undefined`)
 
-		expect(result.module?.content).toMatchInlineSnapshot()
-		expect(result.module?.start).toMatchInlineSnapshot()
-		expect(result.module?.end).toMatchInlineSnapshot()
+		expect(result.module?.content).toMatchInlineSnapshot(`console.log("hello");`)
+		expect(result.module?.start).toMatchInlineSnapshot(`13`)
+		expect(result.module?.end).toMatchInlineSnapshot(`84`)
 	})
 })

--- a/packages/houdini-common/src/parse.test.ts
+++ b/packages/houdini-common/src/parse.test.ts
@@ -159,7 +159,7 @@ describe('parser tests', () => {
 		expect(result.module?.end).toMatchInlineSnapshot(`84`)
 	})
 
-	test("logic in template doesn't break things", () => {
+	test("else in template doesn't break things", () => {
 		// parse the string
 		const result = parseFile(`
             <script context='module'>

--- a/packages/houdini-common/src/parse.test.ts
+++ b/packages/houdini-common/src/parse.test.ts
@@ -230,6 +230,30 @@ describe('parser tests', () => {
 		checkScriptBounds(doc, result)
 	})
 
+	test('self-closing tags', () => {
+		const doc = `
+			<svelte:head>
+				<link />
+			</svelte:head>
+			<script>
+				console.log('hello')
+			</script>
+		`
+
+		// parse the string
+		const result = parseFile(doc)
+
+		expect(result.instance?.content).toMatchInlineSnapshot(`console.log("hello");`)
+		expect(result.instance?.start).toMatchInlineSnapshot(`52`)
+		expect(result.instance?.end).toMatchInlineSnapshot(`97`)
+
+		expect(result.module?.content).toMatchInlineSnapshot(`undefined`)
+		expect(result.module?.start).toMatchInlineSnapshot(`undefined`)
+		expect(result.module?.end).toMatchInlineSnapshot(`undefined`)
+
+		checkScriptBounds(doc, result)
+	})
+
 	test('comments', () => {
 		const doc = `
 			<!-- <script context='module'> -->

--- a/packages/houdini-common/src/parse.test.ts
+++ b/packages/houdini-common/src/parse.test.ts
@@ -5,29 +5,29 @@ describe('parser tests', () => {
 	test('happy path - separate module and instance script', () => {
 		// parse the string
 		const result = parseFile(`
-            <script context="module">
-                console.log('module')
-            </script>
+			<script context="module">
+				console.log('module')
+			</script>
 
-            <script>
-                console.log('instance')
-            </script>
-        `)
+			<script>
+				console.log('instance')
+			</script>
+		`)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`console.log("instance");`)
-		expect(result.instance?.start).toMatchInlineSnapshot(`112`)
-		expect(result.instance?.end).toMatchInlineSnapshot(`181`)
+		expect(result.instance?.start).toMatchInlineSnapshot(`73`)
+		expect(result.instance?.end).toMatchInlineSnapshot(`121`)
 
 		expect(result.module?.content).toMatchInlineSnapshot(`console.log("module");`)
-		expect(result.module?.start).toMatchInlineSnapshot(`13`)
-		expect(result.module?.end).toMatchInlineSnapshot(`97`)
+		expect(result.module?.start).toMatchInlineSnapshot(`4`)
+		expect(result.module?.end).toMatchInlineSnapshot(`67`)
 	})
 
 	test('happy path - start on first character', () => {
 		// parse the string
 		const result = parseFile(`<script context="module">
-                console.log('module')
-            </script>`)
+				console.log('module')
+			</script>`)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
@@ -35,37 +35,37 @@ describe('parser tests', () => {
 
 		expect(result.module?.content).toMatchInlineSnapshot(`console.log("module");`)
 		expect(result.module?.start).toMatchInlineSnapshot(`0`)
-		expect(result.module?.end).toMatchInlineSnapshot(`84`)
+		expect(result.module?.end).toMatchInlineSnapshot(`63`)
 	})
 
 	test('happy path - only module', () => {
 		// parse the string
 		const result = parseFile(`
-            <script context="module">
-                console.log('module')
-            </script>
-        `)
+			<script context="module">
+				console.log('module')
+			</script>
+		`)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.end).toMatchInlineSnapshot(`undefined`)
 
 		expect(result.module?.content).toMatchInlineSnapshot(`console.log("module");`)
-		expect(result.module?.start).toMatchInlineSnapshot(`13`)
-		expect(result.module?.end).toMatchInlineSnapshot(`97`)
+		expect(result.module?.start).toMatchInlineSnapshot(`4`)
+		expect(result.module?.end).toMatchInlineSnapshot(`67`)
 	})
 
 	test('happy path - only instance', () => {
 		// parse the string
 		const result = parseFile(`
-            <script>
-                console.log('module')
-            </script>
-        `)
+			<script>
+				console.log('module')
+			</script>
+		`)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`console.log("module");`)
-		expect(result.instance?.start).toMatchInlineSnapshot(`13`)
-		expect(result.instance?.end).toMatchInlineSnapshot(`80`)
+		expect(result.instance?.start).toMatchInlineSnapshot(`4`)
+		expect(result.instance?.end).toMatchInlineSnapshot(`50`)
 
 		expect(result.module?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.module?.start).toMatchInlineSnapshot(`undefined`)
@@ -75,27 +75,27 @@ describe('parser tests', () => {
 	test('single quotes', () => {
 		// parse the string
 		const result = parseFile(`
-            <script context='module'>
-                console.log('module')
-            </script>
-        `)
+			<script context='module'>
+				console.log('module')
+			</script>
+		`)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.end).toMatchInlineSnapshot(`undefined`)
 
 		expect(result.module?.content).toMatchInlineSnapshot(`console.log("module");`)
-		expect(result.module?.start).toMatchInlineSnapshot(`13`)
-		expect(result.module?.end).toMatchInlineSnapshot(`97`)
+		expect(result.module?.start).toMatchInlineSnapshot(`4`)
+		expect(result.module?.end).toMatchInlineSnapshot(`67`)
 	})
 
 	test('happy path - typescript', () => {
 		// parse the string
 		const result = parseFile(`
-            <script context="module" lang="ts">
+			<script context="module" lang="ts">
 				type Foo = { hello: string}
-            </script>
-        `)
+			</script>
+		`)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
@@ -106,19 +106,19 @@ describe('parser tests', () => {
 		    hello: string
 		};
 	`)
-		expect(result.module?.start).toMatchInlineSnapshot(`13`)
-		expect(result.module?.end).toMatchInlineSnapshot(`101`)
+		expect(result.module?.start).toMatchInlineSnapshot(`4`)
+		expect(result.module?.end).toMatchInlineSnapshot(`83`)
 	})
 
 	test('nested script block', () => {
 		// parse the string
 		const result = parseFile(`
-	        <div>
+			<div>
 				<script>
 					console.log('inner')
 				</script>
-	        </div>
-	    `)
+			</div>
+		`)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
@@ -135,9 +135,9 @@ describe('parser tests', () => {
 			<script>
 				console.log('script')
 			</script>
-	        <div>
-	        </div>
-	    `)
+			<div>
+			</div>
+		`)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`console.log("script");`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`4`)
@@ -151,12 +151,12 @@ describe('parser tests', () => {
 	test("logic in script doesn't break things", () => {
 		// parse the string
 		const result = parseFile(`
-            <script context='module'>
+			<script context='module'>
 				if (1<2) {
 					console.log('hello')
 				}
-            </script>
-        `)
+			</script>
+		`)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
@@ -167,49 +167,49 @@ describe('parser tests', () => {
 		    console.log("hello");
 		}
 	`)
-		expect(result.module?.start).toMatchInlineSnapshot(`13`)
-		expect(result.module?.end).toMatchInlineSnapshot(`106`)
+		expect(result.module?.start).toMatchInlineSnapshot(`4`)
+		expect(result.module?.end).toMatchInlineSnapshot(`88`)
 	})
 
 	test("logic in template doesn't break things", () => {
 		// parse the string
 		const result = parseFile(`
-            <script context='module'>
+			<script context='module'>
 				console.log('hello')
-            </script>
+			</script>
 			{#if foo < 2}
 				<div>
 					hello
 				</div>
 			{/if}
-        `)
+		`)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.end).toMatchInlineSnapshot(`undefined`)
 
 		expect(result.module?.content).toMatchInlineSnapshot(`console.log("hello");`)
-		expect(result.module?.start).toMatchInlineSnapshot(`13`)
-		expect(result.module?.end).toMatchInlineSnapshot(`84`)
+		expect(result.module?.start).toMatchInlineSnapshot(`4`)
+		expect(result.module?.end).toMatchInlineSnapshot(`66`)
 	})
 
 	test('comments', () => {
 		// parse the string
 		const result = parseFile(`
-            <!-- <script context='module'> -->
+			<!-- <script context='module'> -->
 			<script>
 				console.log('hello')
-            </script>
+			</script>
 			{#if foo < 2}
 				<div>
 					hello
 				</div>
 			{/if}
-        `)
+		`)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`console.log("hello");`)
-		expect(result.instance?.start).toMatchInlineSnapshot(`51`)
-		expect(result.instance?.end).toMatchInlineSnapshot(`105`)
+		expect(result.instance?.start).toMatchInlineSnapshot(`42`)
+		expect(result.instance?.end).toMatchInlineSnapshot(`87`)
 
 		expect(result.module?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.module?.start).toMatchInlineSnapshot(`undefined`)
@@ -219,9 +219,9 @@ describe('parser tests', () => {
 	test("else in template doesn't break things", () => {
 		// parse the string
 		const result = parseFile(`
-            <script context='module'>
+			<script context='module'>
 				console.log('hello')
-            </script>
+			</script>
 			{#if foo < 2}
 				<div>
 					hello
@@ -231,43 +231,43 @@ describe('parser tests', () => {
 					hello
 				</div>
 			{/if}
-        `)
+		`)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.end).toMatchInlineSnapshot(`undefined`)
 
 		expect(result.module?.content).toMatchInlineSnapshot(`console.log("hello");`)
-		expect(result.module?.start).toMatchInlineSnapshot(`13`)
-		expect(result.module?.end).toMatchInlineSnapshot(`84`)
+		expect(result.module?.start).toMatchInlineSnapshot(`4`)
+		expect(result.module?.end).toMatchInlineSnapshot(`66`)
 	})
 
 	test('expression in content', () => {
 		// parse the string
 		const result = parseFile(`
-            <script context='module'>
+			<script context='module'>
 				console.log('hello')
-            </script>
+			</script>
 			<div>
 				{hello}
 			</div>
-        `)
+		`)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.end).toMatchInlineSnapshot(`undefined`)
 
 		expect(result.module?.content).toMatchInlineSnapshot(`console.log("hello");`)
-		expect(result.module?.start).toMatchInlineSnapshot(`13`)
-		expect(result.module?.end).toMatchInlineSnapshot(`84`)
+		expect(result.module?.start).toMatchInlineSnapshot(`4`)
+		expect(result.module?.end).toMatchInlineSnapshot(`66`)
 	})
 
 	test('expression attribute', () => {
 		// parse the string
 		const result = parseFile(`
-            <script context='module'>
+			<script context='module'>
 				console.log('hello')
-            </script>
+			</script>
 			{#if foo < 2}
 				<div>
 					hello
@@ -277,14 +277,14 @@ describe('parser tests', () => {
 					hello
 				</div>
 			{/if}
-        `)
+		`)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.end).toMatchInlineSnapshot(`undefined`)
 
 		expect(result.module?.content).toMatchInlineSnapshot(`console.log("hello");`)
-		expect(result.module?.start).toMatchInlineSnapshot(`13`)
-		expect(result.module?.end).toMatchInlineSnapshot(`84`)
+		expect(result.module?.start).toMatchInlineSnapshot(`4`)
+		expect(result.module?.end).toMatchInlineSnapshot(`66`)
 	})
 })

--- a/packages/houdini-common/src/parse.ts
+++ b/packages/houdini-common/src/parse.ts
@@ -198,7 +198,7 @@ function parse(str: string): { instance: StackElement | null; module: StackEleme
 		}
 
 		// if we ran into the start or finish of a logic block
-		if (['{#', '{/', '{:'].includes(content.substr(0, '{#'.length))) {
+		if (['{#', '{/', '{:', '{{'].includes(content.substr(0, '{#'.length))) {
 			// ignore the entire block
 			takeUntilIgnoringNested('}', '{')
 		}
@@ -214,32 +214,38 @@ const parseTag = (str: string) => {
 		endOfTagName = str.length - 1
 	}
 	const tagName = str.substr(0, endOfTagName + 1)
-	const attributes = str
-		.slice(endOfTagName + 1)
-		.trim()
-		.replace(/\n/g, ' ')
-		.split(/\s/)
-		.filter(Boolean)
-		.map((pair) => {
-			// attributes are defined with an equal
-			const [key, value] = pair.split('=')
+	const tag = tagName.trim()
 
-			return {
-				key: key[0] === '"' ? JSON.parse(key) : key,
-				// JSON.parse accepts double quotes only, not single quote
-				value: JSON.parse(value.replace(/'/g, '"')),
-			}
-		})
-		.reduce<{ [key: string]: any }>(
-			(acc, pair) => ({
-				...acc,
-				[pair.key]: pair.value,
-			}),
-			{}
-		)
+	// only compute the attributes for scripts
+	const attributes =
+		tag !== 'script'
+			? {}
+			: str
+					.slice(endOfTagName + 1)
+					.trim()
+					.replace(/\n/g, ' ')
+					.split(/\s/)
+					.filter(Boolean)
+					.map((pair) => {
+						// attributes are defined with an equal
+						const [key, value] = pair.split('=')
+
+						return {
+							key: key[0] === '"' ? JSON.parse(key) : key,
+							// JSON.parse accepts double quotes only, not single quote
+							value: JSON.parse(value.replace(/'/g, '"')),
+						}
+					})
+					.reduce<{ [key: string]: any }>(
+						(acc, pair) => ({
+							...acc,
+							[pair.key]: pair.value,
+						}),
+						{}
+					)
 
 	return {
-		tag: tagName.trim(),
+		tag,
 		attributes,
 	}
 }

--- a/packages/houdini-common/src/parse.ts
+++ b/packages/houdini-common/src/parse.ts
@@ -138,6 +138,15 @@ function parse(str: string): { instance: StackElement | null; module: StackEleme
 	while (content.length > 0) {
 		const head = pop()
 
+		// if we are inside of a script tag, we should just ignore what we found unless its a closing tag
+		if (
+			stack.length > 0 &&
+			stack[stack.length - 1].tag === 'script' &&
+			content.substr(0, '/script'.length) !== '/script'
+		) {
+			continue
+		}
+
 		// if we found a comment
 		if (head + content.substr(0, '!--'.length) === '<!--') {
 			// consume the string until we are at the end of the comment
@@ -148,15 +157,6 @@ function parse(str: string): { instance: StackElement | null; module: StackEleme
 
 		// if the character indicates the start or end of a tag
 		if (head === '<') {
-			// if we are inside of a script tag, we should just ignore what we found unless its a closing tag
-			if (
-				stack.length > 0 &&
-				stack[stack.length - 1].tag === 'script' &&
-				content.substr(0, '/script'.length) !== '/script'
-			) {
-				continue
-			}
-
 			// collect everything until the closing >
 			let tag = takeTil('>').slice(0, -1).trim()
 

--- a/packages/houdini-common/src/parse.ts
+++ b/packages/houdini-common/src/parse.ts
@@ -194,14 +194,18 @@ function parse(str: string): { instance: StackElement | null; module: StackEleme
 			// look at the rest of the
 			const { tag: tagName, attributes } = parseTag(tag)
 
-			// add the tagname to the stack
-			stack.push({
-				tag: tagName,
-				attributes,
-				start: index,
-				// pop increments by one, so if we are starting the tag here, we're one ahead
-				startOfTag: index - tag.length - 1,
-			})
+			// if the last character is a / then we have a self closing tag, nothing goes on the stack
+			if (tag.slice(-1) !== '/') {
+				// add the tagname to the stack
+				stack.push({
+					tag: tagName,
+					attributes,
+					start: index,
+					// pop increments by one, so if we are starting the tag here, we're one ahead
+					startOfTag: index - tag.length - 1,
+				})
+			}
+
 			// we're done processing the string
 			continue
 		}

--- a/packages/houdini-common/src/parse.ts
+++ b/packages/houdini-common/src/parse.ts
@@ -214,7 +214,6 @@ function parse(str: string): { instance: StackElement | null; module: StackEleme
 
 			// if the last character is a / then we have a self closing tag, nothing goes on the stack
 			if (tag.slice(-1) !== '/') {
-				console.log({ tagName })
 				// add the tagname to the stack
 				stack.push({
 					tag: tagName,

--- a/packages/houdini-common/src/parse.ts
+++ b/packages/houdini-common/src/parse.ts
@@ -201,7 +201,6 @@ function parse(str: string): { instance: StackElement | null; module: StackEleme
 					tag: tagName,
 					attributes,
 					start: index,
-					// pop increments by one, so if we are starting the tag here, we're one ahead
 					startOfTag: index - tag.length - 1,
 				})
 			}

--- a/packages/houdini-common/src/parse.ts
+++ b/packages/houdini-common/src/parse.ts
@@ -193,12 +193,12 @@ function parse(str: string): { instance: StackElement | null; module: StackEleme
 				attributes,
 				start: index,
 				// pop() increments index so we really started 1 before where we think we did
-				startOfTag: index - tag.length - 1 - 1,
+				startOfTag: index - 1 - tag.length - 1,
 			})
 		}
 
 		// if we ran into the start or finish of a logic block
-		if (['{#', '{/', '{:', '{{'].includes(content.substr(0, '{#'.length))) {
+		if (['{#', '{/', '{:'].includes(content.substr(0, '{#'.length))) {
 			// ignore the entire block
 			takeUntilIgnoringNested('}', '{')
 		}

--- a/packages/houdini-common/src/parse.ts
+++ b/packages/houdini-common/src/parse.ts
@@ -117,9 +117,6 @@ function parse(str: string): { instance: StackElement | null; module: StackEleme
 		// the last character we saw
 		let head = ''
 
-		// we know that the head matches so eat it and keep looking
-		head = pop()
-
 		// keep eating until we found the closing `finish`
 		while (count > 0 && content.length > 0) {
 			// consume one character from the string

--- a/packages/houdini-common/src/parse.ts
+++ b/packages/houdini-common/src/parse.ts
@@ -214,6 +214,7 @@ function parse(str: string): { instance: StackElement | null; module: StackEleme
 
 			// if the last character is a / then we have a self closing tag, nothing goes on the stack
 			if (tag.slice(-1) !== '/') {
+				console.log({ tagName })
 				// add the tagname to the stack
 				stack.push({
 					tag: tagName,
@@ -241,7 +242,7 @@ function parse(str: string): { instance: StackElement | null; module: StackEleme
 
 const parseTag = (str: string) => {
 	// the first characters before a space gives us the name of the tag
-	let endOfTagName = str.indexOf(' ')
+	let endOfTagName = str.match(/\s/)?.index || -1
 	if (endOfTagName === -1) {
 		endOfTagName = str.length - 1
 	}

--- a/packages/houdini-common/src/parse.ts
+++ b/packages/houdini-common/src/parse.ts
@@ -181,7 +181,7 @@ function parse(str: string): { instance: StackElement | null; module: StackEleme
 		}
 
 		// if we ran into the start or finish of a logic block
-		if (['{#', '{/'].includes(content.substr(0, '{#'.length))) {
+		if (['{#', '{/', '{:'].includes(content.substr(0, '{#'.length))) {
 			// ignore the entire block
 			takeUntilIgnoringNested('}', '{')
 		}

--- a/packages/houdini-common/src/parse.ts
+++ b/packages/houdini-common/src/parse.ts
@@ -7,16 +7,6 @@ type ParsedSvelteFile = {
 	module: Maybe<Script>
 }
 
-type StackElement = {
-	tag: string
-	attributes: { [key: string]: string }
-	start: number
-	end?: number
-	content?: string
-}
-
-type StackElementWithStart = StackElement & { startOfTag: number }
-
 export function parseFile(str: string): ParsedSvelteFile {
 	// look for the instance and module scripts
 	const { instance, module } = parse(str)
@@ -40,6 +30,7 @@ export function parseFile(str: string): ParsedSvelteFile {
 				sourceType: 'module',
 			}).program,
 			start: script.start,
+			// end has to exist to get this far
 			end: script.end!,
 		}
 	}
@@ -47,6 +38,16 @@ export function parseFile(str: string): ParsedSvelteFile {
 	// we're done here
 	return result
 }
+
+type StackElement = {
+	tag: string
+	attributes: { [key: string]: string }
+	start: number
+	end?: number
+	content?: string
+}
+
+type StackElementWithStart = StackElement & { startOfTag: number }
 
 function parse(str: string): { instance: StackElement | null; module: StackElement | null } {
 	// offset the script by one so the iterator can start at index 0 pointing at the first element
@@ -164,7 +165,7 @@ function parse(str: string): { instance: StackElement | null; module: StackEleme
 
 					// dry the result
 					const script = {
-						start: innerElement.startOfTag - 1,
+						start: innerElement.startOfTag,
 						end: innerElement.end + tag.length,
 						content,
 						tag: innerElement.tag,
@@ -191,7 +192,8 @@ function parse(str: string): { instance: StackElement | null; module: StackEleme
 				tag: tagName,
 				attributes,
 				start: index,
-				startOfTag: index - tag.length - 1,
+				// pop() increments index so we really started 1 before where we think we did
+				startOfTag: index - tag.length - 1 - 1,
 			})
 		}
 

--- a/packages/houdini-common/src/parse.ts
+++ b/packages/houdini-common/src/parse.ts
@@ -69,13 +69,17 @@ function parse(str: string): { instance: StackElement | null; module: StackEleme
 	const takeTil = (char: string) => {
 		let head = pop()
 		let acc = head
-		while (head !== char && content.length > 0) {
+		let tail = ''
+
+		// consume characters from content until we get something matching our target
+		while (tail !== char && content.length > 0) {
 			head = pop()
 			acc += head
+			tail = acc.substr(acc.length - char.length)
 		}
 
 		// if the last character is not what we were looking for
-		if (acc[acc.length - 1] !== char) {
+		if (tail !== char) {
 			throw new Error('Could not find ' + char)
 		}
 
@@ -110,6 +114,12 @@ function parse(str: string): { instance: StackElement | null; module: StackEleme
 	}
 
 	while (content.length > 0) {
+		// if we found a commend
+		if (content.substr(0, '<!--'.length) === '<!--') {
+			// consume the string until we are at the end of the comment
+			takeTil('-->')
+		}
+
 		// pull out the head of the string
 		const head = pop()
 

--- a/packages/houdini-common/src/parse.ts
+++ b/packages/houdini-common/src/parse.ts
@@ -15,6 +15,8 @@ type StackElement = {
 	content?: string
 }
 
+type StackElementWithStart = StackElement & { startOfTag: number }
+
 export function parseFile(str: string): ParsedSvelteFile {
 	// look for the instance and module scripts
 	const { instance, module } = parse(str)
@@ -50,7 +52,7 @@ function parse(str: string): { instance: StackElement | null; module: StackEleme
 	let content = str
 
 	// we need to step through the document and find scripts that are at the root of the document
-	const stack = [] as StackElement[]
+	const stack = [] as StackElementWithStart[]
 	let index = 0
 
 	let module: StackElement | null = null
@@ -115,8 +117,8 @@ function parse(str: string): { instance: StackElement | null; module: StackEleme
 
 					// dry the result
 					const script = {
-						start,
-						end,
+						start: innerElement.startOfTag,
+						end: innerElement.end + tag.length + 1,
 						content,
 						tag: innerElement.tag,
 						attributes: innerElement.attributes,
@@ -142,6 +144,7 @@ function parse(str: string): { instance: StackElement | null; module: StackEleme
 				tag: tagName,
 				attributes,
 				start: index,
+				startOfTag: index - tag.length - 1,
 			})
 		}
 	}

--- a/packages/houdini-preprocess/package.json
+++ b/packages/houdini-preprocess/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini-preprocess",
-	"version": "0.7.2-rc.0",
+	"version": "0.7.2-rc.1",
 	"description": "",
 	"main": "build/cjs/index.js",
 	"module": "build/esm/index.js",
@@ -35,8 +35,8 @@
 		"babylon": "^7.0.0-beta.47",
 		"estree-walker": "^2.0.2",
 		"graphql": "15.5.0",
-		"houdini": "^0.7.2-rc.0",
-		"houdini-common": "^0.7.2-rc.0",
+		"houdini": "^0.7.2-rc.1",
+		"houdini-common": "^0.7.2-rc.1",
 		"mkdirp": "^1.0.4",
 		"prettier": "*",
 		"prettier-plugin-svelte": "^2.1.1",

--- a/packages/houdini-preprocess/package.json
+++ b/packages/houdini-preprocess/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini-preprocess",
-	"version": "0.7.2-rc.2",
+	"version": "0.7.2-rc.3",
 	"description": "",
 	"main": "build/cjs/index.js",
 	"module": "build/esm/index.js",
@@ -35,8 +35,8 @@
 		"babylon": "^7.0.0-beta.47",
 		"estree-walker": "^2.0.2",
 		"graphql": "15.5.0",
-		"houdini": "^0.7.2-rc.2",
-		"houdini-common": "^0.7.2-rc.2",
+		"houdini": "^0.7.2-rc.3",
+		"houdini-common": "^0.7.2-rc.3",
 		"mkdirp": "^1.0.4",
 		"prettier": "*",
 		"prettier-plugin-svelte": "^2.1.1",

--- a/packages/houdini-preprocess/package.json
+++ b/packages/houdini-preprocess/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini-preprocess",
-	"version": "0.7.1",
+	"version": "0.7.2-rc.0",
 	"description": "",
 	"main": "build/cjs/index.js",
 	"module": "build/esm/index.js",
@@ -35,8 +35,8 @@
 		"babylon": "^7.0.0-beta.47",
 		"estree-walker": "^2.0.2",
 		"graphql": "15.5.0",
-		"houdini": "^0.7.1",
-		"houdini-common": "^0.7.0",
+		"houdini": "^0.7.2-rc.0",
+		"houdini-common": "^0.7.2-rc.0",
 		"mkdirp": "^1.0.4",
 		"prettier": "*",
 		"prettier-plugin-svelte": "^2.1.1",

--- a/packages/houdini-preprocess/package.json
+++ b/packages/houdini-preprocess/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini-preprocess",
-	"version": "0.7.2-rc.1",
+	"version": "0.7.2-rc.2",
 	"description": "",
 	"main": "build/cjs/index.js",
 	"module": "build/esm/index.js",
@@ -35,8 +35,8 @@
 		"babylon": "^7.0.0-beta.47",
 		"estree-walker": "^2.0.2",
 		"graphql": "15.5.0",
-		"houdini": "^0.7.2-rc.1",
-		"houdini-common": "^0.7.2-rc.1",
+		"houdini": "^0.7.2-rc.2",
+		"houdini-common": "^0.7.2-rc.2",
 		"mkdirp": "^1.0.4",
 		"prettier": "*",
 		"prettier-plugin-svelte": "^2.1.1",

--- a/packages/houdini-preprocess/package.json
+++ b/packages/houdini-preprocess/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini-preprocess",
-	"version": "0.7.2-rc.3",
+	"version": "0.7.2-rc.4",
 	"description": "",
 	"main": "build/cjs/index.js",
 	"module": "build/esm/index.js",
@@ -35,8 +35,8 @@
 		"babylon": "^7.0.0-beta.47",
 		"estree-walker": "^2.0.2",
 		"graphql": "15.5.0",
-		"houdini": "^0.7.2-rc.3",
-		"houdini-common": "^0.7.2-rc.3",
+		"houdini": "^0.7.2-rc.4",
+		"houdini-common": "^0.7.2-rc.4",
 		"mkdirp": "^1.0.4",
 		"prettier": "*",
 		"prettier-plugin-svelte": "^2.1.1",

--- a/packages/houdini-preprocess/src/test.ts
+++ b/packages/houdini-preprocess/src/test.ts
@@ -46,7 +46,7 @@ describe('preprocessor can replace content', function () {
 		</div>`)
 	})
 
-	test('update instance content', async function () {
+	test('update module content', async function () {
 		// the source
 		const content = `
         <script context="module">
@@ -203,8 +203,7 @@ describe('preprocessor can replace content', function () {
 	test('add module', async function () {
 		// the source
 		const content = `
-        <script>
-		</script>
+        <script></script>
 		<div>
 		helllo
 		</div>

--- a/packages/houdini-preprocess/src/transforms/index.ts
+++ b/packages/houdini-preprocess/src/transforms/index.ts
@@ -23,7 +23,9 @@ export default async function applyTransforms(
 	// a single transform might need to do different things to the module and
 	// instance scripts so we're going to pull them out, push them through separately,
 	// and then join them back together
-	const scripts = parseFile(doc.content)
+	const scripts = parseFile(doc.content, {
+		filename: doc.filename,
+	})
 
 	// wrap everything up in an object we'll thread through the transforms
 	const result: types.TransformDocument = {

--- a/packages/houdini/cmd/generate.ts
+++ b/packages/houdini/cmd/generate.ts
@@ -60,7 +60,9 @@ async function collectDocuments(config: Config): Promise<CollectedGraphQLDocumen
 			const contents = await fs.readFile(filePath, 'utf-8')
 
 			// parse the contents
-			const parsedFile = parseFile(contents)
+			const parsedFile = parseFile(contents, {
+				filename: filePath,
+			})
 
 			// we need to look for multiple script tags to support sveltekit
 			const scripts = [parsedFile.instance, parsedFile.module]

--- a/packages/houdini/package-lock.json
+++ b/packages/houdini/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini",
-	"version": "0.7.2-rc.0",
+	"version": "0.7.2-rc.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/houdini/package-lock.json
+++ b/packages/houdini/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini",
-	"version": "0.7.2-rc.3",
+	"version": "0.7.2-rc.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/houdini/package-lock.json
+++ b/packages/houdini/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini",
-	"version": "0.7.2-rc.1",
+	"version": "0.7.2-rc.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/houdini/package-lock.json
+++ b/packages/houdini/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini",
-	"version": "0.7.2-rc.2",
+	"version": "0.7.2-rc.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/houdini/package-lock.json
+++ b/packages/houdini/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini",
-	"version": "0.7.1",
+	"version": "0.7.2-rc.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/houdini/package.json
+++ b/packages/houdini/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini",
-	"version": "0.7.2-rc.2",
+	"version": "0.7.2-rc.3",
 	"description": "",
 	"scripts": {
 		"build:runtime": "npm run build:runtime:cjs && npm run build:runtime:esm",
@@ -42,7 +42,7 @@
 		"estree-walker": "^2.0.2",
 		"glob": "^7.1.6",
 		"graphql": "^15.5.0",
-		"houdini-common": "^0.7.2-rc.2",
+		"houdini-common": "^0.7.2-rc.3",
 		"inquirer": "^7.3.3",
 		"mkdirp": "^1.0.4",
 		"node-fetch": "^2.6.1",

--- a/packages/houdini/package.json
+++ b/packages/houdini/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini",
-	"version": "0.7.1",
+	"version": "0.7.2-rc.0",
 	"description": "",
 	"scripts": {
 		"build:runtime": "npm run build:runtime:cjs && npm run build:runtime:esm",
@@ -42,7 +42,7 @@
 		"estree-walker": "^2.0.2",
 		"glob": "^7.1.6",
 		"graphql": "^15.5.0",
-		"houdini-common": "^0.7.0",
+		"houdini-common": "^0.7.2-rc.0",
 		"inquirer": "^7.3.3",
 		"mkdirp": "^1.0.4",
 		"node-fetch": "^2.6.1",

--- a/packages/houdini/package.json
+++ b/packages/houdini/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini",
-	"version": "0.7.2-rc.3",
+	"version": "0.7.2-rc.4",
 	"description": "",
 	"scripts": {
 		"build:runtime": "npm run build:runtime:cjs && npm run build:runtime:esm",
@@ -42,7 +42,7 @@
 		"estree-walker": "^2.0.2",
 		"glob": "^7.1.6",
 		"graphql": "^15.5.0",
-		"houdini-common": "^0.7.2-rc.3",
+		"houdini-common": "^0.7.2-rc.4",
 		"inquirer": "^7.3.3",
 		"mkdirp": "^1.0.4",
 		"node-fetch": "^2.6.1",

--- a/packages/houdini/package.json
+++ b/packages/houdini/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini",
-	"version": "0.7.2-rc.0",
+	"version": "0.7.2-rc.1",
 	"description": "",
 	"scripts": {
 		"build:runtime": "npm run build:runtime:cjs && npm run build:runtime:esm",
@@ -42,7 +42,7 @@
 		"estree-walker": "^2.0.2",
 		"glob": "^7.1.6",
 		"graphql": "^15.5.0",
-		"houdini-common": "^0.7.2-rc.0",
+		"houdini-common": "^0.7.2-rc.1",
 		"inquirer": "^7.3.3",
 		"mkdirp": "^1.0.4",
 		"node-fetch": "^2.6.1",

--- a/packages/houdini/package.json
+++ b/packages/houdini/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini",
-	"version": "0.7.2-rc.1",
+	"version": "0.7.2-rc.2",
 	"description": "",
 	"scripts": {
 		"build:runtime": "npm run build:runtime:cjs && npm run build:runtime:esm",
@@ -42,7 +42,7 @@
 		"estree-walker": "^2.0.2",
 		"glob": "^7.1.6",
 		"graphql": "^15.5.0",
-		"houdini-common": "^0.7.2-rc.1",
+		"houdini-common": "^0.7.2-rc.2",
 		"inquirer": "^7.3.3",
 		"mkdirp": "^1.0.4",
 		"node-fetch": "^2.6.1",


### PR DESCRIPTION
After struggling for a long time to get the svelte preprocessor infrastructure from #101 working, I decided to flesh out the custom parser to isolate only the top-level scripts for a document's `module` and `instance` scripts.

@thormuller @georgecrawford @pixelmund  - mind running your application with these changes and see if anything pops up? I tried to add tests for as many weird edge cases as I could but i'm sure I'm missing something.

it is available as version `0.7.2-rc.4`  which _should_  be tagged with `@next`

fixes #100 