### PR TITLE
Static mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ If you are working on an application that isn't using SvelteKit or Sapper, you h
 compiler and preprocessor to generate the correct logic by setting the `framework` field in your
 config file to `"svelte"`. 
 
+Please keep in mind that returning the response from a query, you should not rely on `this.redirect` to handle the 
+redirect as it will update your browsers `location` attribute, causing a hard transition to that url. Instead, you should
+use `this.error` to return an error and handle the redirect in a way that's appropriate for your application.
+
 ## 🚀&nbsp;&nbsp;Fetching Data
 
 Grabbing data from your API is done with the `query` function:

--- a/README.md
+++ b/README.md
@@ -174,12 +174,15 @@ If you have updated your schema on the server, you can pull down the most recent
 npx houdini generate --pull-schema
 ```
 
+**Note**: If you are building your application with 
+[`adapter-static`](https://github.com/sveltejs/kit/tree/master/packages/adapter-static) (or any other adapter that turns
+your application into a static site), you will need to set the `static` value in your config file to `true`. 
+
 ### Svelte
 
 If you are working on an application that isn't using SvelteKit or Sapper, you have to configure the
 compiler and preprocessor to generate the correct logic by setting the `framework` field in your
-config file to `"svelte"`. You should also use this setting if you are building a SvelteKit application
-in SPA mode.
+config file to `"svelte"`. 
 
 ## 🚀&nbsp;&nbsp;Fetching Data
 

--- a/packages/houdini-common/src/config.ts
+++ b/packages/houdini-common/src/config.ts
@@ -15,6 +15,7 @@ export type ConfigFile = {
 	mode?: 'kit' | 'sapper'
 	framework?: 'kit' | 'sapper' | 'svelte'
 	module?: 'esm' | 'commonjs'
+	static?: boolean
 }
 
 // a place to hold conventions and magic strings
@@ -27,6 +28,7 @@ export class Config {
 	schemaPath?: string
 	sourceGlob: string
 	quiet: boolean
+	static?: boolean
 	framework: 'sapper' | 'kit' | 'svelte' = 'sapper'
 	module: 'commonjs' | 'esm' = 'commonjs'
 
@@ -39,6 +41,7 @@ export class Config {
 		filepath,
 		framework = 'sapper',
 		module = 'commonjs',
+		static: staticSite,
 		mode,
 	}: ConfigFile & { filepath: string }) {
 		// make sure we got some kind of schema
@@ -90,6 +93,7 @@ export class Config {
 		this.framework = framework
 		this.module = module
 		this.projectRoot = path.dirname(filepath)
+		this.static = staticSite
 
 		// if we are building a sapper project, we want to put the runtime in
 		// src/node_modules so that we can access @sapper/app and interact

--- a/packages/houdini-preprocess/src/transforms/query.test.ts
+++ b/packages/houdini-preprocess/src/transforms/query.test.ts
@@ -238,6 +238,54 @@ describe('query preprocessor', function () {
 	`)
 	})
 
+	test('svelte kit with static set', async function () {
+		const doc = await preprocessorTest(
+			`
+			<script>
+				const { data } = query(graphql\`
+					query TestQuery {
+						viewer {
+							id
+						}
+					}
+				\`)
+			</script>
+		`,
+			{
+				mode: 'kit',
+				// if we are in a route but static is set to true, we need to treat the file like a
+				// svelte component
+				route: true,
+				static: true,
+			}
+		)
+
+		// make sure we added the right stuff
+		expect(doc.module?.content).toMatchInlineSnapshot(``)
+		expect(doc.instance?.content).toMatchInlineSnapshot(`
+		import { routeQuery, componentQuery, query } from "$houdini";
+		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
+		export let _TestQuery = undefined;
+		export let _TestQuery_Input = undefined;
+
+		let _TestQuery_handler = query({
+		    "initialValue": _TestQuery,
+		    "variables": _TestQuery_Input,
+		    "kind": "HoudiniQuery",
+		    "artifact": _TestQueryArtifact
+		});
+
+		const {
+		    data
+		} = componentQuery({
+		    queryHandler: _TestQuery_handler,
+		    artifact: _TestQueryArtifact,
+		    variableFunction: null,
+		    getProps: () => $$props
+		});
+	`)
+	})
+
 	test('non-route page - no variables', async function () {
 		const doc = await preprocessorTest(
 			`

--- a/packages/houdini-preprocess/src/transforms/query.ts
+++ b/packages/houdini-preprocess/src/transforms/query.ts
@@ -36,6 +36,7 @@ export default async function queryProcessor(
 	// how we preprocess a query depends on wether its a route/layout component
 	const isRoute =
 		config.framework !== 'svelte' &&
+		!config.static &&
 		doc.filename.startsWith(path.join(config.projectRoot, 'src', 'routes'))
 
 	// figure out the root type

--- a/packages/houdini/cmd/generators/runtime/adapter.ts
+++ b/packages/houdini/cmd/generators/runtime/adapter.ts
@@ -8,7 +8,11 @@ export default async function generateAdapter(config: Config) {
 	const adapterLocation = path.join(config.runtimeDirectory, 'adapter.mjs')
 
 	// figure out which adapter we need to lay down
-	const adapter = config.framework === 'sapper' ? sapperAdapter : sveltekitAdapter
+	const adapter = {
+		sapper: sapperAdapter,
+		kit: sveltekitAdapter,
+		svelte: svelteAdapter,
+	}[config.framework]
 
 	// write the index file that exports the runtime
 	await writeFile(adapterLocation, adapter)
@@ -34,5 +38,15 @@ export function getSession() {
 
 export function goTo(location, options) {
     go(location, options)
+}
+`
+
+const svelteAdapter = `
+export function getSession() {
+	return {}
+}
+
+export function goTo(location, options) {
+	window.location = location
 }
 `


### PR DESCRIPTION
This PR separates the static-mode support from the support for bare-svelte applications by adding an addition `static` option to the config file which causes every `query` to be handled like a bare svelte app but still generates the kit adapter. I also added a svelte adapter that avoid importing from `$app` which fixes #67. Along the way I address a problem with handling errors encountered while computing variables for non-route components.