### PR TITLE
Use svelte parser instead of custom one

### DIFF
--- a/packages/houdini-common/src/parse.test.ts
+++ b/packages/houdini-common/src/parse.test.ts
@@ -5,7 +5,7 @@ import '../../../jest.setup'
 import { parseFile, ParsedSvelteFile } from './parse'
 
 describe('parser tests', () => {
-	test('happy path - separate module and instance script', () => {
+	test('happy path - separate module and instance script', async () => {
 		const doc = `
 		<script context="module">
 			console.log('module')
@@ -17,7 +17,7 @@ describe('parser tests', () => {
 	`
 
 		// parse the string
-		const result = parseFile(doc)
+		const result = await parseFile(doc)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`console.log("instance");`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`69`)
@@ -30,12 +30,12 @@ describe('parser tests', () => {
 		checkScriptBounds(doc, result)
 	})
 
-	test('happy path - start on first character', () => {
+	test('happy path - start on first character', async () => {
 		const doc = `<script context="module">
 				console.log('module')
 			</script>`
 		// parse the string
-		const result = parseFile(doc)
+		const result = await parseFile(doc)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
@@ -48,14 +48,14 @@ describe('parser tests', () => {
 		checkScriptBounds(doc, result)
 	})
 
-	test('happy path - only module', () => {
+	test('happy path - only module', async () => {
 		const doc = `
 			<script context="module">
 				console.log('module')
 			</script>
 		`
 		// parse the string
-		const result = parseFile(doc)
+		const result = await parseFile(doc)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
@@ -68,14 +68,14 @@ describe('parser tests', () => {
 		checkScriptBounds(doc, result)
 	})
 
-	test('happy path - only instance', () => {
+	test('happy path - only instance', async () => {
 		const doc = `
 			<script>
 				console.log('module')
 			</script>
 		`
 		// parse the string
-		const result = parseFile(doc)
+		const result = await parseFile(doc)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`console.log("module");`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`4`)
@@ -88,14 +88,14 @@ describe('parser tests', () => {
 		checkScriptBounds(doc, result)
 	})
 
-	test('single quotes', () => {
+	test('single quotes', async () => {
 		const doc = `
 			<script context='module'>
 				console.log('module')
 			</script>
 		`
 		// parse the string
-		const result = parseFile(doc)
+		const result = await parseFile(doc)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
@@ -108,14 +108,14 @@ describe('parser tests', () => {
 		checkScriptBounds(doc, result)
 	})
 
-	test('happy path - typescript', () => {
+	test('happy path - typescript', async () => {
 		const doc = `
 			<script context="module" lang="ts">
 				type Foo = { hello: string}
 			</script>
 		`
 		// parse the string
-		const result = parseFile(doc)
+		const result = await parseFile(doc)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
@@ -132,7 +132,7 @@ describe('parser tests', () => {
 		checkScriptBounds(doc, result)
 	})
 
-	test('nested script block', () => {
+	test('nested script block', async () => {
 		const doc = `
 			<div>
 				<script>
@@ -142,7 +142,7 @@ describe('parser tests', () => {
 		`
 
 		// parse the string
-		const result = parseFile(doc)
+		const result = await parseFile(doc)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
@@ -155,7 +155,7 @@ describe('parser tests', () => {
 		checkScriptBounds(doc, result)
 	})
 
-	test('script next to html', () => {
+	test('script next to html', async () => {
 		const doc = `
 			<script>
 				console.log('script')
@@ -165,7 +165,7 @@ describe('parser tests', () => {
 		`
 
 		// parse the string
-		const result = parseFile(doc)
+		const result = await parseFile(doc)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`console.log("script");`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`4`)
@@ -178,7 +178,7 @@ describe('parser tests', () => {
 		checkScriptBounds(doc, result)
 	})
 
-	test("logic in script doesn't break things", () => {
+	test("logic in script doesn't break things", async () => {
 		const doc = `
 			<script context='module'>
 				if (1<2) {
@@ -187,7 +187,7 @@ describe('parser tests', () => {
 			</script>
 		`
 		// parse the string
-		const result = parseFile(doc)
+		const result = await parseFile(doc)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
@@ -204,7 +204,7 @@ describe('parser tests', () => {
 		checkScriptBounds(doc, result)
 	})
 
-	test("logic in template doesn't break things", () => {
+	test("logic in template doesn't break things", async () => {
 		const doc = `
 			<script context='module'>
 				console.log('hello')
@@ -217,7 +217,7 @@ describe('parser tests', () => {
 		`
 
 		// parse the string
-		const result = parseFile(doc)
+		const result = await parseFile(doc)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
@@ -230,7 +230,7 @@ describe('parser tests', () => {
 		checkScriptBounds(doc, result)
 	})
 
-	test('self-closing tags', () => {
+	test('self-closing tags', async () => {
 		const doc = `
 			<svelte:head>
 				<link />
@@ -241,7 +241,7 @@ describe('parser tests', () => {
 		`
 
 		// parse the string
-		const result = parseFile(doc)
+		const result = await parseFile(doc)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`console.log("hello");`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`52`)
@@ -254,7 +254,7 @@ describe('parser tests', () => {
 		checkScriptBounds(doc, result)
 	})
 
-	test('comments', () => {
+	test('comments', async () => {
 		const doc = `
 			<!-- <script context='module'> -->
 			<script>
@@ -268,7 +268,7 @@ describe('parser tests', () => {
 		`
 
 		// parse the string
-		const result = parseFile(doc)
+		const result = await parseFile(doc)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`console.log("hello");`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`42`)
@@ -281,7 +281,7 @@ describe('parser tests', () => {
 		checkScriptBounds(doc, result)
 	})
 
-	test("else in template doesn't break things", () => {
+	test("else in template doesn't break things", async () => {
 		const doc = `
 			<script context='module'>
 				console.log('hello')
@@ -298,7 +298,7 @@ describe('parser tests', () => {
 		`
 
 		// parse the string
-		const result = parseFile(doc)
+		const result = await parseFile(doc)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
@@ -311,7 +311,7 @@ describe('parser tests', () => {
 		checkScriptBounds(doc, result)
 	})
 
-	test('expression in content', () => {
+	test('expression in content', async () => {
 		const doc = `
 			<script context='module'>
 				console.log('hello')
@@ -321,7 +321,7 @@ describe('parser tests', () => {
 			</div>
 		`
 		// parse the string
-		const result = parseFile(doc)
+		const result = await parseFile(doc)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
@@ -334,7 +334,7 @@ describe('parser tests', () => {
 		checkScriptBounds(doc, result)
 	})
 
-	test('expression attribute', () => {
+	test('expression attribute', async () => {
 		const doc = `
 			{#if foo < 2}
 				<div>
@@ -345,7 +345,7 @@ describe('parser tests', () => {
 					the crazy <div is to trick the parser into thinking there's
 					a new tag inside of an expression
 				-->
-				<div attribute={foo > && <div 2} foo>
+				<div attribute={foo > 2 && div < 2} foo>
 					hello
 					<div>
 						inner
@@ -357,20 +357,20 @@ describe('parser tests', () => {
 			</script>
 		`
 		// parse the string
-		const result = parseFile(doc)
+		const result = await parseFile(doc)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
 		expect(result.instance?.end).toMatchInlineSnapshot(`undefined`)
 
 		expect(result.module?.content).toMatchInlineSnapshot(`console.log("hello");`)
-		expect(result.module?.start).toMatchInlineSnapshot(`304`)
-		expect(result.module?.end).toMatchInlineSnapshot(`366`)
+		expect(result.module?.start).toMatchInlineSnapshot(`307`)
+		expect(result.module?.end).toMatchInlineSnapshot(`369`)
 
 		checkScriptBounds(doc, result)
 	})
 
-	test('tabs to end tags', () => {
+	test('tabs to end tags', async () => {
 		const doc = `<script lang="ts">
 			console.log('hello')
 		</script>
@@ -393,7 +393,7 @@ describe('parser tests', () => {
 	`
 
 		// parse the string
-		const result = parseFile(doc)
+		const result = await parseFile(doc)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`console.log("hello");`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`0`)
@@ -406,7 +406,7 @@ describe('parser tests', () => {
 		checkScriptBounds(doc, result)
 	})
 
-	test('empty object in script', () => {
+	test('empty object in script', async () => {
 		const doc = `<script lang="ts">
 		const example = object({});
 	</script>
@@ -415,7 +415,7 @@ describe('parser tests', () => {
 	`
 
 		// parse the string
-		const result = parseFile(doc)
+		const result = await parseFile(doc)
 
 		expect(result.instance?.content).toMatchInlineSnapshot(`const example = object({});`)
 		expect(result.instance?.start).toMatchInlineSnapshot(`0`)
@@ -426,39 +426,6 @@ describe('parser tests', () => {
 		expect(result.module?.end).toMatchInlineSnapshot(`undefined`)
 
 		checkScriptBounds(doc, result)
-	})
-
-	test('empty expression', () => {
-		const doc = `
-	<div foo={}>hello</div>
-	`
-
-		// parse the string
-		const result = parseFile(doc)
-
-		expect(result.instance?.content).toMatchInlineSnapshot(`undefined`)
-		expect(result.instance?.start).toMatchInlineSnapshot(`undefined`)
-		expect(result.instance?.end).toMatchInlineSnapshot(`undefined`)
-
-		expect(result.module?.content).toMatchInlineSnapshot(`undefined`)
-		expect(result.module?.start).toMatchInlineSnapshot(`undefined`)
-		expect(result.module?.end).toMatchInlineSnapshot(`undefined`)
-
-		checkScriptBounds(doc, result)
-	})
-
-	test('error messages include line number', () => {
-		try {
-			// parse the string
-			parseFile(`
-				<div`)
-
-			fail('no error thrown')
-		} catch (e) {
-			const message = (e as Error).message
-
-			expect(message).toContain('line 2')
-		}
 	})
 })
 

--- a/packages/houdini-common/src/parse.ts
+++ b/packages/houdini-common/src/parse.ts
@@ -1,5 +1,6 @@
 // locals
 import type { Maybe, Script } from './types'
+import * as svelte from 'svelte/compiler'
 import { parse as parseJS } from '@babel/parser'
 
 export type ParsedSvelteFile = {
@@ -7,56 +8,50 @@ export type ParsedSvelteFile = {
 	module: Maybe<Script>
 }
 
-export type ParserOpts = {
-	filename?: string
-}
-
-type ParserError = { message: string; lineNumber: number }
-
-export function parseFile(str: string, opts?: ParserOpts): ParsedSvelteFile {
-	// look for the instance and module scripts
-	let instance: StackElement | null
-	let module: StackElement | null
-	try {
-		const result = parse(str)
-		instance = result.instance
-		module = result.module
-	} catch (e) {
-		// pull the message and line number out of the erro
-		const { message, lineNumber } = e as ParserError
-
-		// do we have a filename
-		const filename = opts?.filename || 'testFile'
-
-		// bubble the error up
-		throw new Error(
-			`Encountered error${
-				lineNumber ? ` on line ${lineNumber}` : ''
-			} while parsing ${filename}: ${message}`
-		)
-	}
+export async function parseFile(str: string): Promise<ParsedSvelteFile> {
+	// parsing a file happens in two steps:
+	// - first we use svelte's parser to find the bounds of the script tag
+	// - then we run the contents through babel to parse it
+	const preprocessed = await svelte.preprocess(str, [
+		{
+			script({ content: input }) {
+				return {
+					code: input.replace(/\S/g, ' '),
+				}
+			},
+		},
+	])
+	// parse the result to find the bounds
+	const parsed = svelte.parse(preprocessed.code)
 
 	// build up the result
-	const result: ParsedSvelteFile = {
-		instance: null,
-		module: null,
-	}
+	const result: ParsedSvelteFile = { instance: null, module: null }
 
-	// parse both of the scripts
-	for (const [i, script] of [instance, module].entries()) {
+	// look at the instance and module of the parsed result to find the correct bounds
+	for (const which of ['instance', 'module'] as ('instance' | 'module')[]) {
 		// figure out which we're parsing
+		const script = parsed[which]
 		if (!script) {
 			continue
 		}
 
-		result[i === 0 ? 'instance' : 'module'] = {
-			content: parseJS(script.content || '', {
+		// now that we have the bounds we can find the appropriate string to parse
+		const [greaterThanIndex, lessThanIndex] = findScriptInnerBounds({
+			start: parsed[which].start,
+			end: parsed[which].end - 1,
+			text: str,
+		})
+
+		const string = str.slice(greaterThanIndex, lessThanIndex)
+
+		result[which] = {
+			content: parseJS(string || '', {
 				plugins: ['typescript'],
 				sourceType: 'module',
 			}).program,
-			start: script.start,
+			start: parsed[which].start,
 			// end has to exist to get this far
-			end: script.end!,
+			end: parsed[which].end! - 1,
 		}
 	}
 
@@ -64,240 +59,46 @@ export function parseFile(str: string, opts?: ParserOpts): ParsedSvelteFile {
 	return result
 }
 
-type StackElement = {
-	tag: string
-	attributes: { [key: string]: string }
+export function findScriptInnerBounds({
+	start,
+	end,
+	text,
+}: {
 	start: number
-	end?: number
-	content?: string
-}
-
-type StackElementWithStart = StackElement & { startOfTag: number }
-
-function parse(str: string): { instance: StackElement | null; module: StackElement | null } {
-	// offset the script by one so the iterator can start at index 0 pointing at the first element
-	let content = str
-
-	// we need to step through the document and find scripts that are at the root of the document
-	const stack = [] as StackElementWithStart[]
-	let index = -1
-
-	let module: StackElement | null = null
-	let instance: StackElement | null = null
-
-	// count the number of lines
-	let lineNumber = 1
-
-	const ErrorWithLineNumber = (message: string) => {
-		return {
-			message,
-			lineNumber,
+	end: number
+	text: string
+}): [number, number] {
+	// {start} points to the < of the opening tag, we want to find the >
+	let greaterThanIndex = start
+	// keep looking until the end
+	while (greaterThanIndex < end) {
+		// if we found the > we can stop looking
+		if (text[greaterThanIndex] === '>') {
+			break
 		}
+
+		// keep looking
+		greaterThanIndex++
+	}
+	// if we didn't find it
+	if (greaterThanIndex === start) {
+		throw new Error('Could not find the end of the tag open')
 	}
 
-	const pop = () => {
-		const head = content.slice(0, 1)
-		content = content.slice(1, content.length)
-		index++
-
-		// if we found a newline, increment the line count
-		if (head === '\n') {
-			lineNumber++
+	// {end} points to the > of the closing tag
+	let lessThanIndex = end
+	while (lessThanIndex > greaterThanIndex) {
+		// if we found the < we can stop looking
+		if (text[lessThanIndex] === '<') {
+			break
 		}
-
-		return head
+		// keep looking
+		lessThanIndex--
+	}
+	// if we didn't find it
+	if (lessThanIndex === end) {
+		throw new Error('Could not find the start of the tag close')
 	}
 
-	const takeTil = (char: string) => {
-		let head = pop()
-		let acc = head
-		let tail = head
-
-		// consume characters from content until we get something matching our target
-		while (tail !== char && content.length > 0) {
-			head = pop()
-			acc += head
-			tail = acc.substr(-char.length)
-			// if we ran into the start or finish of a logic block before we continue
-			if (head === '{') {
-				// ignore the entire block
-				takeUntilIgnoringNested('}', '{')
-				continue
-			}
-		}
-
-		// if the last character is not what we were looking for
-		if (tail !== char) {
-			throw ErrorWithLineNumber('could not find ' + char)
-		}
-
-		return acc
-	}
-
-	const takeUntilIgnoringNested = (finish: string, start: string) => {
-		// we need to count instances of `start` that we run into to find the one that closes the one we found
-		let count = 1
-		// the last character we saw
-		let head = ''
-
-		// keep eating until we found the closing `finish`
-		while (count > 0 && content.length > 0) {
-			// consume one character from the string
-			head = pop()
-
-			if (head === start) {
-				count++
-			} else if (head === finish) {
-				count--
-			}
-		}
-
-		// if the last character we saw was not the finishing character, there was a problem
-		if (head !== finish) {
-			throw ErrorWithLineNumber(`did not encounter matching ${finish}.`)
-		}
-	}
-
-	while (content.length > 0) {
-		const head = pop()
-
-		// if we are inside of a script tag, we should just ignore what we found unless its a closing tag
-		if (
-			stack.length > 0 &&
-			stack[stack.length - 1].tag === 'script' &&
-			content.substr(0, '/script'.length) !== '/script'
-		) {
-			continue
-		}
-
-		// if we found a comment
-		if (head + content.substr(0, '!--'.length) === '<!--') {
-			// consume the string until we are at the end of the comment
-			takeTil('-->')
-			// we're done
-			continue
-		}
-
-		// if the character indicates the start or end of a tag
-		if (head === '<') {
-			// collect everything until the closing >
-			let tag = takeTil('>').slice(0, -1).trim()
-
-			// if the first character denotes we're actually closing a tag
-			if (tag[0] === '/') {
-				// remove the last element from the stack
-				const innerElement = stack.pop()
-				const tagName = tag.substr(1)
-				if (!innerElement || innerElement.tag !== parseTag(tagName).tag) {
-					throw ErrorWithLineNumber(
-						`unexpected closing tag ${parseTag(tagName).tag}, expected ${
-							innerElement?.tag
-						}.`
-					)
-				}
-
-				//  the index is the end of the tag
-				innerElement.end = index - innerElement.tag.length - 2
-
-				// if we ended a script that's at the top of the stack
-				if (innerElement.tag === 'script' && stack.length === 0) {
-					// dry the bounds
-					const start = innerElement.start + 1
-					const end = innerElement.end
-
-					// get the content of the script
-					const content = str.slice(start, end - 1).trim()
-
-					// dry the result
-					const script = {
-						start: innerElement.startOfTag,
-						end: innerElement.end + tag.length + 1,
-						content,
-						tag: innerElement.tag,
-						attributes: innerElement.attributes,
-					}
-
-					// if we are looking at the module context
-					if (innerElement.attributes.context === 'module') {
-						module = script
-					} else {
-						instance = script
-					}
-				}
-
-				// keep moving
-				continue
-			}
-
-			// look at the rest of the
-			const { tag: tagName, attributes } = parseTag(tag)
-
-			// if the last character is a / then we have a self closing tag, nothing goes on the stack
-			if (tag.slice(-1) !== '/') {
-				// add the tagname to the stack
-				stack.push({
-					tag: tagName,
-					attributes,
-					start: index,
-					startOfTag: index - tag.length - 1,
-				})
-			}
-
-			// we're done processing the string
-			continue
-		}
-
-		// if we ran into the start or finish of a logic block
-		if (head === '{') {
-			// ignore the entire block
-			takeUntilIgnoringNested('}', '{')
-			// keep processing the rest of the string
-			continue
-		}
-	}
-
-	return { instance, module }
-}
-
-const parseTag = (str: string) => {
-	// the first characters before a space gives us the name of the tag
-	let endOfTagName = str.match(/\s/)?.index || -1
-	if (endOfTagName === -1) {
-		endOfTagName = str.length - 1
-	}
-	const tagName = str.substr(0, endOfTagName + 1)
-	const tag = tagName.trim()
-
-	// only compute the attributes for scripts
-	const attributes =
-		tag !== 'script'
-			? {}
-			: str
-					.slice(endOfTagName + 1)
-					.trim()
-					.replace(/\n/g, ' ')
-					.split(/\s/)
-					.filter(Boolean)
-					.map((pair) => {
-						// attributes are defined with an equal
-						const [key, value] = pair.split('=')
-
-						return {
-							key: key[0] === '"' ? JSON.parse(key) : key,
-							// JSON.parse accepts double quotes only, not single quote
-							value: JSON.parse(value.replace(/'/g, '"')),
-						}
-					})
-					.reduce<{ [key: string]: any }>(
-						(acc, pair) => ({
-							...acc,
-							[pair.key]: pair.value,
-						}),
-						{}
-					)
-
-	return {
-		tag,
-		attributes,
-	}
+	return [greaterThanIndex + 1, lessThanIndex]
 }

--- a/packages/houdini-preprocess/src/test.ts
+++ b/packages/houdini-preprocess/src/test.ts
@@ -109,7 +109,7 @@ describe('preprocessor can replace content', function () {
 	test('parses typescript', async function () {
 		// the source
 		const content = `
-        <script "lang"="ts">
+        <script lang="ts">
 			type Foo = { hello: string }
 		</script>
 `
@@ -123,9 +123,11 @@ describe('preprocessor can replace content', function () {
 		const result = await applyTransforms(config, { content, filename: 'test' }, [])
 
 		// make sure we got the result back
-		expect(result.code.trim()).toBe(`<script "lang"="ts">type Foo = {
-    hello: string
-};</script>`)
+		expect(result.code.trim()).toMatchInlineSnapshot(`
+		"<script lang=\\"ts\\">type Foo = {
+		    hello: string
+		};</script>"
+	`)
 	})
 
 	test('modify both at the same time (module above instance)', async function () {

--- a/packages/houdini-preprocess/src/transforms/index.ts
+++ b/packages/houdini-preprocess/src/transforms/index.ts
@@ -1,6 +1,6 @@
 // externals
 import * as recast from 'recast'
-import { runPipeline, Config, Transform, parseFile } from 'houdini-common'
+import { runPipeline, Config, Transform, parseFile, findScriptInnerBounds } from 'houdini-common'
 // locals
 import * as types from '../types'
 import fragmentProcessor from './fragment'
@@ -23,7 +23,7 @@ export default async function applyTransforms(
 	// a single transform might need to do different things to the module and
 	// instance scripts so we're going to pull them out, push them through separately,
 	// and then join them back together
-	const scripts = parseFile(doc.content, {
+	const scripts = await parseFile(doc.content, {
 		filename: doc.filename,
 	})
 
@@ -153,40 +153,10 @@ function replaceTagContent(
 		return `<script${attrs}>${insert}</script>${source}`
 	}
 
-	// {start} points to the < of the opening tag, we want to find the >
-	let greaterThanIndex = start
-	// keep looking until the end
-	while (greaterThanIndex < end) {
-		// if we found the > we can stop looking
-		if (source[greaterThanIndex] === '>') {
-			break
-		}
-
-		// keep looking
-		greaterThanIndex++
-	}
-	// if we didn't find it
-	if (greaterThanIndex === start) {
-		throw new Error('Could not find the end of the tag open')
-	}
-
-	// {end} points to the > of the closing tag
-	let lessThanIndex = end
-	while (lessThanIndex > greaterThanIndex) {
-		// if we found the < we can stop looking
-		if (source[lessThanIndex] === '<') {
-			break
-		}
-		// keep looking
-		lessThanIndex--
-	}
-	// if we didn't find it
-	if (lessThanIndex === end) {
-		throw new Error('Could not find the start of the tag close')
-	}
+	const [greaterThanIndex, lessThanIndex] = findScriptInnerBounds({ start, end, text: source })
 
 	// replace the content between the closing of the open and open of the close
-	return replaceBetween(source, greaterThanIndex + 1, lessThanIndex, insert)
+	return replaceBetween(source, greaterThanIndex, lessThanIndex, insert)
 }
 
 // replaceSubstring replaces the substring string between the indices with the provided new value

--- a/packages/houdini-preprocess/src/transforms/index.ts
+++ b/packages/houdini-preprocess/src/transforms/index.ts
@@ -23,9 +23,7 @@ export default async function applyTransforms(
 	// a single transform might need to do different things to the module and
 	// instance scripts so we're going to pull them out, push them through separately,
 	// and then join them back together
-	const scripts = await parseFile(doc.content, {
-		filename: doc.filename,
-	})
+	const scripts = await parseFile(doc.content)
 
 	// wrap everything up in an object we'll thread through the transforms
 	const result: types.TransformDocument = {

--- a/packages/houdini/cmd/generate.ts
+++ b/packages/houdini/cmd/generate.ts
@@ -61,7 +61,7 @@ async function collectDocuments(config: Config): Promise<CollectedGraphQLDocumen
 
 			let parsedFile: ParsedSvelteFile
 			try {
-				parsedFile = parseFile(contents, {
+				parsedFile = await parseFile(contents, {
 					filename: filePath,
 				})
 			} catch (e) {

--- a/packages/houdini/cmd/generate.ts
+++ b/packages/houdini/cmd/generate.ts
@@ -61,9 +61,7 @@ async function collectDocuments(config: Config): Promise<CollectedGraphQLDocumen
 
 			let parsedFile: ParsedSvelteFile
 			try {
-				parsedFile = await parseFile(contents, {
-					filename: filePath,
-				})
+				parsedFile = await parseFile(contents)
 			} catch (e) {
 				const err = e as Error
 


### PR DESCRIPTION
This PR updates houdini's internal to use the one from svelte instead of the one I recently wrote. This should keep houdini significantly more resilient and saves us the headache of maintaining complex code. 