### PR TITLE
Recursive input types

### DIFF
--- a/packages/houdini/cmd/generators/typescript.test.ts
+++ b/packages/houdini/cmd/generators/typescript.test.ts
@@ -13,6 +13,10 @@ import { mockCollectedDoc } from '../testUtils'
 // the config to use in tests
 const config = testConfig({
 	schema: `
+		enum MyEnum { 
+			Hello
+		}
+
 		type Query {
 			user(id: ID, filter: UserFilter, filterList: [UserFilter!]): User
 			users: [User]
@@ -34,6 +38,8 @@ const config = testConfig({
 			middle: NestedUserFilter
 			listRequired: [String!]!
 			nullList: [String]
+			recursive: UserFilter
+			enum: MyEnum
 		}
 
 		input NestedUserFilter {
@@ -353,29 +359,29 @@ describe('typescript', function () {
 		    } | null
 		};
 
+		type NestedUserFilter = {
+		    id: string,
+		    firstName: string,
+		    admin: boolean | null | undefined,
+		    age: number | null | undefined,
+		    weight: number | null | undefined
+		};
+
+		enum MyEnum {
+		    Hello = "Hello"
+		}
+
+		type UserFilter = {
+		    middle: NestedUserFilter | null | undefined,
+		    listRequired: (string)[],
+		    nullList: (string | null | undefined)[] | null | undefined,
+		    recursive: UserFilter | null | undefined,
+		    enum: MyEnum | null | undefined
+		};
+
 		export type Mutation$input = {
-		    filter: {
-		        middle: {
-		            id: string,
-		            firstName: string,
-		            admin: boolean | null | undefined,
-		            age: number | null | undefined,
-		            weight: number | null | undefined
-		        } | null | undefined,
-		        listRequired: (string)[],
-		        nullList: (string | null | undefined)[] | null | undefined
-		    } | null | undefined,
-		    filterList: ({
-		        middle: {
-		            id: string,
-		            firstName: string,
-		            admin: boolean | null | undefined,
-		            age: number | null | undefined,
-		            weight: number | null | undefined
-		        } | null | undefined,
-		        listRequired: (string)[],
-		        nullList: (string | null | undefined)[] | null | undefined
-		    })[],
+		    filter: UserFilter | null | undefined,
+		    filterList: (UserFilter)[],
 		    id: string,
 		    firstName: string,
 		    admin: boolean | null | undefined,
@@ -415,18 +421,28 @@ describe('typescript', function () {
 		    } | null
 		};
 
+		type NestedUserFilter = {
+		    id: string,
+		    firstName: string,
+		    admin: boolean | null | undefined,
+		    age: number | null | undefined,
+		    weight: number | null | undefined
+		};
+
+		enum MyEnum {
+		    Hello = "Hello"
+		}
+
+		type UserFilter = {
+		    middle: NestedUserFilter | null | undefined,
+		    listRequired: (string)[],
+		    nullList: (string | null | undefined)[] | null | undefined,
+		    recursive: UserFilter | null | undefined,
+		    enum: MyEnum | null | undefined
+		};
+
 		export type Query$input = {
-		    filter: {
-		        middle: {
-		            id: string,
-		            firstName: string,
-		            admin: boolean | null | undefined,
-		            age: number | null | undefined,
-		            weight: number | null | undefined
-		        } | null | undefined,
-		        listRequired: (string)[],
-		        nullList: (string | null | undefined)[] | null | undefined
-		    }
+		    filter: UserFilter
 		};
 	`)
 	})

--- a/packages/houdini/cmd/generators/typescript.ts
+++ b/packages/houdini/cmd/generators/typescript.ts
@@ -150,6 +150,11 @@ async function generateOperationTypeDefs(
 
 		// if there are variables in this query
 		if (hasInputs) {
+			// we need to pull out any of the input types as separate definitions to avoid recursive typedefs
+			for (const variableDefinition of definition.variableDefinitions) {
+				addReferencedInputTypes(config, body, variableDefinition.type)
+			}
+
 			// merge all of the variables into a single object
 			body.push(
 				AST.exportNamedDeclaration(
@@ -170,6 +175,17 @@ async function generateOperationTypeDefs(
 			)
 		}
 	}
+}
+
+// add any object types found in the input
+function addReferencedInputTypes(
+	config: Config,
+	body: StatementKind[],
+	type: graphql.TypeNode | graphql.NamedTypeNode,
+	visitedTypes: Record<string, boolean> = {}
+) {
+	// try to find the name of the type
+	const name = type.kind === 'NamedType' ? type.name.value : ''
 }
 
 // return the property

--- a/packages/houdini/cmd/generators/typescript.ts
+++ b/packages/houdini/cmd/generators/typescript.ts
@@ -149,7 +149,11 @@ async function generateOperationTypeDefs(
 		)
 
 		// if there are variables in this query
-		if (hasInputs && definition.variableDefinitions.length > 0) {
+		if (
+			hasInputs &&
+			definition.variableDefinitions &&
+			definition.variableDefinitions.length > 0
+		) {
 			// we need to pull out any of the input types as separate definitions to avoid recursive typedefs
 			const visitedTypes = new Set<string>()
 			for (const variableDefinition of definition.variableDefinitions) {

--- a/packages/houdini/cmd/generators/typescript.ts
+++ b/packages/houdini/cmd/generators/typescript.ts
@@ -149,7 +149,7 @@ async function generateOperationTypeDefs(
 		)
 
 		// if there are variables in this query
-		if (hasInputs) {
+		if (hasInputs && definition.variableDefinitions.length > 0) {
 			// we need to pull out any of the input types as separate definitions to avoid recursive typedefs
 			const visitedTypes = new Set<string>()
 			for (const variableDefinition of definition.variableDefinitions) {

--- a/packages/houdini/cmd/generators/typescript.ts
+++ b/packages/houdini/cmd/generators/typescript.ts
@@ -7,7 +7,7 @@ import { TSTypeKind, StatementKind, TSPropertySignatureKind } from 'ast-types/ge
 import path from 'path'
 // locals
 import { CollectedGraphQLDocument } from '../types'
-import { writeFile } from '../utils'
+import { writeFile, unwrapType } from '../utils'
 
 const AST = recast.types.builders
 
@@ -151,8 +151,9 @@ async function generateOperationTypeDefs(
 		// if there are variables in this query
 		if (hasInputs) {
 			// we need to pull out any of the input types as separate definitions to avoid recursive typedefs
+			const visitedTypes = new Set<string>()
 			for (const variableDefinition of definition.variableDefinitions) {
-				addReferencedInputTypes(config, body, variableDefinition.type)
+				addReferencedInputTypes(config, body, visitedTypes, variableDefinition.type)
 			}
 
 			// merge all of the variables into a single object
@@ -166,7 +167,7 @@ async function generateOperationTypeDefs(
 									// add a property describing the variable to the root object
 									AST.tsPropertySignature(
 										AST.identifier(definition.variable.name.value),
-										AST.tsTypeAnnotation(inputType(config, definition))
+										AST.tsTypeAnnotation(tsTypeReference(config, definition))
 									)
 							)
 						)
@@ -181,53 +182,73 @@ async function generateOperationTypeDefs(
 function addReferencedInputTypes(
 	config: Config,
 	body: StatementKind[],
-	type: graphql.TypeNode | graphql.NamedTypeNode,
-	visitedTypes: Record<string, boolean> = {}
+	visitedTypes: Set<string>,
+	rootType: graphql.TypeNode
 ) {
 	// try to find the name of the type
-	const name = type.kind === 'NamedType' ? type.name.value : ''
+	const { type } = unwrapType(config, rootType)
+
+	// if we are looking at a scalar
+	if (graphql.isScalarType(type)) {
+		// we're done
+		return
+	}
+
+	// if we have already processed this type, dont do anything
+	if (visitedTypes.has(type.name)) {
+		return
+	}
+
+	// if we ran into a union
+	if (graphql.isUnionType(type)) {
+		// we don't support them yet
+		throw new Error('Unions are not supported yet. Sorry!')
+	}
+
+	// track that we are processing the type
+	visitedTypes.add(type.name)
+
+	// if we ran into an enum, add its definition to the file
+	if (graphql.isEnumType(type)) {
+		body.push(
+			AST.tsEnumDeclaration(
+				AST.identifier(type.name),
+				type
+					.getValues()
+					.map((value) =>
+						AST.tsEnumMember(AST.identifier(value.name), AST.stringLiteral(value.name))
+					)
+			)
+		)
+		return
+	}
+
+	// we found an object type so build up the list of fields (and walk down any object fields)
+	const members: TSPropertySignatureKind[] = []
+
+	for (const field of Object.values(type.getFields())) {
+		// walk down the referenced fields and build stuff back up
+		addReferencedInputTypes(config, body, visitedTypes, field.type)
+
+		members.push(
+			AST.tsPropertySignature(
+				AST.identifier(field.name),
+				AST.tsTypeAnnotation(tsTypeReference(config, field))
+			)
+		)
+	}
+
+	// add the type def to the body
+	body.push(AST.tsTypeAliasDeclaration(AST.identifier(type.name), AST.tsTypeLiteral(members)))
 }
 
 // return the property
-const inputType = (config: Config, definition: { type: graphql.TypeNode }): TSTypeKind => {
-	let type = definition.type
+const tsTypeReference = (config: Config, definition: { type: graphql.TypeNode }): TSTypeKind => {
+	const { type, nullable: nonNull, nonNull: innerNonNull, list } = unwrapType(
+		config,
+		definition.type
+	)
 
-	// start unwrapping non-nulls and lists (we'll wrap it back up before we return)
-	let nonNull = false
-	if (type.kind === 'NonNullType') {
-		type = type.type
-		nonNull = true
-	}
-	if (type instanceof graphql.GraphQLNonNull) {
-		nonNull = true
-		// @ts-ignore
-		type = type.ofType
-	}
-	let list = false
-	if (type.kind === 'ListType') {
-		type = type.type
-		list = true
-	}
-	if (type instanceof graphql.GraphQLList) {
-		list = true
-		// @ts-ignore
-		type = type.ofType
-	}
-	let innerNonNull = false
-	if (type.kind === 'NonNullType') {
-		type = type.type
-		innerNonNull = true
-	}
-	if (type instanceof graphql.GraphQLNonNull) {
-		innerNonNull = true
-		// @ts-ignore
-		type = type.ofType
-	}
-
-	// make typescript happy
-	if (type.kind !== 'NamedType' && !graphql.isNamedType(type) && !graphql.isScalarType(type)) {
-		throw new Error('Too many wrappers: ' + type.kind)
-	}
 	const namedTypeNode = type as graphql.NamedTypeNode | graphql.GraphQLScalarType
 
 	// now that we have the name of the input type, lets look it up in the schema
@@ -249,15 +270,7 @@ const inputType = (config: Config, definition: { type: graphql.TypeNode }): TSTy
 	// we're looking at an object
 	else {
 		// the fields of the object end up as properties in the type literal
-		result = AST.tsTypeLiteral(
-			Object.values(definitionType.getFields()).map((field) => {
-				return AST.tsPropertySignature(
-					AST.identifier(field.name),
-					// @ts-ignore
-					AST.tsTypeAnnotation(inputType(config, field))
-				)
-			})
-		)
+		result = AST.tsTypeReference(AST.identifier(definitionType.name))
 	}
 
 	// if we are wrapping a list
@@ -362,22 +375,8 @@ function tsType(
 	allowReadonly: boolean
 ): TSTypeKind {
 	// start unwrapping non-nulls and lists (we'll wrap it back up before we return)
-	let type: graphql.GraphQLNullableType = rootType
-	let nonNull = false
-	if (type instanceof graphql.GraphQLNonNull) {
-		type = type.ofType
-		nonNull = true
-	}
-	let list = false
-	if (type instanceof graphql.GraphQLList) {
-		type = type.ofType
-		list = true
-	}
-	let innerNonNull = false
-	if (type instanceof graphql.GraphQLNonNull) {
-		type = type.ofType
-		innerNonNull = true
-	}
+	const { type, list, nullable: nonNull, nonNull: innerNonNull } = unwrapType(config, rootType)
+
 	let result: TSTypeKind
 	// if we are looking at a scalar field
 	if (isScalarType(type)) {

--- a/packages/houdini/cmd/utils/graphql.ts
+++ b/packages/houdini/cmd/utils/graphql.ts
@@ -1,0 +1,51 @@
+import * as graphql from 'graphql'
+import { Config } from 'houdini-common'
+
+export function unwrapType(
+	config: Config,
+	source: any
+): { type: graphql.GraphQLNamedType; list: boolean; nonNull: boolean; nullable: boolean } {
+	// build a reference we will unwrap
+	let type = source
+	// start unwrapping non-nulls and lists (we'll wrap it back up before we return)
+	let nonNull = false
+	if (type.kind === 'NonNullType') {
+		type = type.type
+		nonNull = true
+	}
+	if (type instanceof graphql.GraphQLNonNull) {
+		nonNull = true
+		type = type.ofType
+	}
+	let list = false
+	if (type.kind === 'ListType') {
+		type = type.type
+		list = true
+	}
+	if (type instanceof graphql.GraphQLList) {
+		type = type.ofType
+		list = true
+	}
+	let innerNonNull = false
+	if (type.kind === 'NonNullType') {
+		type = type.type
+		innerNonNull = true
+	}
+	if (type instanceof graphql.GraphQLNonNull) {
+		type = type.ofType
+		innerNonNull = true
+	}
+
+	// get the named type
+	const namedType = config.schema.getType(type.name.value || type.name)
+	if (!namedType) {
+		throw new Error('Could not unwrap type: ' + source)
+	}
+
+	return {
+		type: namedType,
+		nullable: nonNull,
+		nonNull: innerNonNull,
+		list,
+	}
+}

--- a/packages/houdini/cmd/utils/index.ts
+++ b/packages/houdini/cmd/utils/index.ts
@@ -1,3 +1,4 @@
 export { default as moduleExport } from './moduleExport'
 export * from './commonjs'
 export * from './writeFile'
+export * from './graphql'


### PR DESCRIPTION
This PR fixes the input type generation to allow for recursive input types. Previously, the type generator would flatten the type definition into a single object which clearly doesn't work in an input type references itself.

closes #111 