### PR TITLE
Custom scalars

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ for the generation of an incredibly lean GraphQL abstraction for your applicatio
     1. [Sapper](#sapper)
     1. [SvelteKit](#sveltekit)
     1. [Svelte](#svelte)
+1. [Config File](#config-file)
 1. [Running the Compiler](#running-the-compiler)
 1. [Fetching Data](#fetching-data)
     1. [Query variables and page data](#query-variables-and-page-data)
@@ -187,6 +188,13 @@ config file to `"svelte"`.
 Please keep in mind that returning the response from a query, you should not rely on `this.redirect` to handle the 
 redirect as it will update your browsers `location` attribute, causing a hard transition to that url. Instead, you should
 use `this.error` to return an error and handle the redirect in a way that's appropriate for your application.
+
+## 📄&nbsp;Config File
+
+All configuration for your houdini application is defined in a single file that is imported by both the runtime and the 
+command-line tool. Because of this, you must make sure that any imports and logic are resolvable in both environments. 
+This means that if you rely on `process.env` or other node-specifics you will have to use a 
+[plugin](https://www.npmjs.com/package/vite-plugin-replace) to replace the expression with something that can run in the browser. 
 
 ## 🚀&nbsp;&nbsp;Fetching Data
 

--- a/README.md
+++ b/README.md
@@ -736,7 +736,6 @@ export default {
 }
 ```
 
-
 ## 🔐&nbsp;&nbsp;Authentication
 
 houdini defers to SvelteKit's sessions for authentication. Assuming that the session has been populated

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ for the generation of an incredibly lean GraphQL abstraction for your applicatio
     1. [Configuring the WebSocket client](#configuring-the-websocket-client)
     1. [Using graphql-ws](#using-graphql-ws)
     1. [Using subscriptions-transport-ws](#using-subscriptions-transport-ws)
+1. [Custom Scalars](#custom-scalars)
 1. [Authentication](#authentication)
 1. [Notes, Constraints, and Conventions](#%EF%B8%8Fnotes-constraints-and-conventions)
 
@@ -704,9 +705,41 @@ if (browser) {
 export default new Environment(fetchQuery, socketClient)
 ```
 
+## ⚖️&nbsp;Custom Scalars
+
+Configuring your runtime to handle custom scalars is done under the `scalars` key in your config:
+
+```javascript
+// houdini.config.js
+
+export default {
+	// ...
+
+	scalars: {
+		// the name of the scalar we are configuring
+		DateTime: {
+			// the corresponding typescript type 
+			type: 'Date',
+			// turn the api's response into that type
+			unmarshal(val) {
+				const date = new Date(0)
+				date.setMilliseconds(val)
+
+				return date
+			},
+			// turn the value into something the API can use
+			marshal(date) {
+				return date.getTime()
+			},
+		},
+	},
+}
+```
+
+
 ## 🔐&nbsp;&nbsp;Authentication
 
-houdini defers to Sapper's sessions for authentication. Assuming that the session has been populated
+houdini defers to SvelteKit's sessions for authentication. Assuming that the session has been populated
 somehow, you can access it through the second argument in the environment definition:
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -722,10 +722,7 @@ export default {
 			type: 'Date',
 			// turn the api's response into that type
 			unmarshal(val) {
-				const date = new Date(0)
-				date.setMilliseconds(val)
-
-				return date
+				return new Date(val)
 			},
 			// turn the value into something the API can use
 			marshal(date) {

--- a/example/houdini.config.js
+++ b/example/houdini.config.js
@@ -4,4 +4,15 @@ export default {
 	framework: 'kit',
 	module: 'esm',
 	apiUrl: 'http://localhost:4000/graphql',
+	scalars: {
+		DateTime: {
+			type: 'Date',
+			marshal(val) {
+				return val.getTime()
+			},
+			unmarshal(val) {
+				return new Date(val)
+			},
+		},
+	},
 }

--- a/example/houdini.config.js
+++ b/example/houdini.config.js
@@ -1,7 +1,5 @@
-import path from 'path'
-
 export default {
-	schemaPath: path.resolve('./schema/schema.gql'),
+	schemaPath: './schema/schema.gql',
 	sourceGlob: 'src/**/*.svelte',
 	framework: 'kit',
 	module: 'esm',

--- a/example/package.json
+++ b/example/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "example-kit",
 	"private": true,
-	"version": "0.8.5",
+	"version": "0.8.6-rc.0",
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",
@@ -12,8 +12,8 @@
 	"devDependencies": {
 		"@sveltejs/kit": "1.0.0-next.107",
 		"graphql": "15.5.0",
-		"houdini": "^0.8.5",
-		"houdini-preprocess": "^0.8.5",
+		"houdini": "^0.8.6-rc.0",
+		"houdini-preprocess": "^0.8.6-rc.0",
 		"svelte": "^3.38.2",
 		"svelte-preprocess": "^4.0.0",
 		"tslib": "^2.2.0",

--- a/example/schema/schema.gql
+++ b/example/schema/schema.gql
@@ -1,59 +1,67 @@
-directive @cacheControl(maxAge: Int, scope: CacheControlScope) on FIELD_DEFINITION | INTERFACE | OBJECT
+directive @cacheControl(
+	maxAge: Int
+	scope: CacheControlScope
+) on FIELD_DEFINITION | INTERFACE | OBJECT
+
+scalar DateTime
 
 input AddItemInput {
-  text: String!
+	text: String!
 }
 
 type AddItemOutput {
-  error: Error
-  item: TodoItem
+	error: Error
+	item: TodoItem
 }
 
 enum CacheControlScope {
-  PRIVATE
-  PUBLIC
+	PRIVATE
+	PUBLIC
 }
 
 type DeleteIemOutput {
-  error: Error
-  itemID: ID
+	error: Error
+	itemID: ID
 }
 
 type Error {
-  code: String!
-  message: String!
+	code: String!
+	message: String!
 }
 
 type ItemUpdate {
-  item: TodoItem!
+	item: TodoItem!
 }
 
 type Mutation {
-  addItem(input: AddItemInput!): AddItemOutput!
-  checkItem(item: ID!): UpdateItemOutput!
-  deleteItem(item: ID!): DeleteIemOutput!
-  uncheckItem(item: ID!): UpdateItemOutput!
+	addItem(input: AddItemInput!): AddItemOutput!
+	checkItem(item: ID!): UpdateItemOutput!
+	deleteItem(item: ID!): DeleteIemOutput!
+	uncheckItem(item: ID!): UpdateItemOutput!
 }
 
 type Query {
-  items(completed: Boolean): [TodoItem!]!
+	items(completed: Boolean): [TodoItem!]!
 }
 
 type Subscription {
-  itemUpdate(id: ID!): ItemUpdate!
-  newItem: ItemUpdate!
+	itemUpdate(id: ID!): ItemUpdate!
+	newItem: ItemUpdate!
 }
 
 type TodoItem {
-  completed: Boolean!
-  id: ID!
-  text: String!
+	completed: Boolean!
+	id: ID!
+	text: String!
+	createdAt: DateTime!
 }
 
 type UpdateItemOutput {
-  error: Error
-  item: TodoItem
+	error: Error
+	item: TodoItem
 }
 
-"""The `Upload` scalar type represents a file upload."""
+"""
+The `Upload` scalar type represents a file upload.
+"""
 scalar Upload

--- a/example/src/app.html
+++ b/example/src/app.html
@@ -5,6 +5,12 @@
 		<link rel="icon" href="/favicon.ico" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%svelte.head%
+		<style rel="stylesheet">
+			body:focus,
+			div:focus {
+				box-shadow: none !important;
+			}
+		</style>
 	</head>
 	<body>
 		<div id="svelte">%svelte.body%</div>

--- a/example/src/lib/ItemEntry.svelte
+++ b/example/src/lib/ItemEntry.svelte
@@ -20,10 +20,13 @@
 				id
 				text
 				completed
+				createdAt
 			}
 		`,
 		item
 	)
+
+	console.log($data.createdAt)
 
 	// create the functions we'll invoke to check, uncheck, and delete the item
 	const completeItem = mutation<CompleteItem>(graphql`

--- a/example/src/lib/ItemEntry.svelte
+++ b/example/src/lib/ItemEntry.svelte
@@ -20,7 +20,6 @@
 				id
 				text
 				completed
-				createdAt
 			}
 		`,
 		item

--- a/example/src/lib/ItemEntry.svelte
+++ b/example/src/lib/ItemEntry.svelte
@@ -20,6 +20,7 @@
 				id
 				text
 				completed
+				createdAt
 			}
 		`,
 		item
@@ -65,6 +66,7 @@
 						id
 						completed
 						text
+						createdAt
 					}
 				}
 			}
@@ -88,8 +90,26 @@
 	}
 </script>
 
+<style>
+	.timestamp { 
+		font-size: 14px;
+		margin-top: 4px;
+		margin-right: 50px;
+	}
+
+	.destroy, input {
+		cursor: pointer;
+	}
+
+	.row {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+	}
+</style>
+
 <li class:completed={$data.completed}>
-	<div class="view">
+	<div class="view" >
 		<input
 			name={$data.text}
 			class="toggle"
@@ -97,7 +117,12 @@
 			checked={$data.completed}
 			on:click={handleClick}
 		/>
-		<label for={$data.text}>{$data.text}</label>
+		<label for={$data.text} class="row">
+			{$data.text} 
+			<span class="timestamp">
+				{$data.createdAt.toLocaleDateString("en-US")}
+			</span>
+		</label>
 		<button class="destroy" on:click={() => deleteItem({ id: $data.id })} />
 	</div>
 </li>

--- a/example/src/lib/ItemEntry.svelte
+++ b/example/src/lib/ItemEntry.svelte
@@ -26,8 +26,6 @@
 		item
 	)
 
-	console.log($data.createdAt)
-
 	// create the functions we'll invoke to check, uncheck, and delete the item
 	const completeItem = mutation<CompleteItem>(graphql`
 		mutation CompleteItem($id: ID!) {

--- a/example/src/routes/[filter].svelte
+++ b/example/src/routes/[filter].svelte
@@ -66,9 +66,6 @@
 		data,
 		($data) => $data.allItems.filter((item) => !item.completed).length
 	)
-	const hasCompleted = derived(data, ($data) =>
-		Boolean($data.allItems.find((item) => item.completed))
-	)
 
 	// figure out the current page
 	const currentPage = derived(page, ($page) => {
@@ -128,8 +125,5 @@
 				<a class:selected={$currentPage === 'completed'} href="/completed">Completed</a>
 			</li>
 		</ul>
-		{#if $hasCompleted}
-			<button class="clear-completed">Clear completed</button>
-		{/if}
 	</footer>
 {/if}

--- a/example/src/routes/[filter].svelte
+++ b/example/src/routes/[filter].svelte
@@ -82,11 +82,13 @@
 
 	let inputValue = ''
 	async function onBlur() {
-		// trigger the mutation
-		await addItem({ input: { text: inputValue } })
+		if (inputValue) {
+			// trigger the mutation
+			await addItem({ input: { text: inputValue } })
 
-		// clear the input
-		inputValue = ''
+			// clear the input
+			inputValue = ''
+		}
 	}
 
 </script>

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
 	"packages": ["packages/*", "example"],
-	"version": "0.8.5",
+	"version": "0.8.6-rc.0",
 	"npmClient": "yarn"
 }

--- a/packages/houdini-common/package.json
+++ b/packages/houdini-common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini-common",
-	"version": "0.8.5",
+	"version": "0.8.6-rc.0",
 	"description": "",
 	"main": "build/cjs/index.js",
 	"module": "build/esm/index.js",

--- a/packages/houdini-common/src/config.ts
+++ b/packages/houdini-common/src/config.ts
@@ -224,7 +224,9 @@ export class Config {
 	}
 
 	isSelectionScalar(type: string) {
-		return ['String', 'ID', 'Float', 'Int', 'Boolean'].includes(type)
+		return ['String', 'Boolean', 'Float', 'ID', 'Int']
+			.concat(Object.keys(this.scalars || {}))
+			.includes(type)
 	}
 
 	async createDirectories(): Promise<void> {

--- a/packages/houdini-preprocess/package.json
+++ b/packages/houdini-preprocess/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini-preprocess",
-	"version": "0.8.5",
+	"version": "0.8.6-rc.0",
 	"description": "",
 	"main": "build/cjs/index.js",
 	"module": "build/esm/index.js",
@@ -35,8 +35,8 @@
 		"babylon": "^7.0.0-beta.47",
 		"estree-walker": "^2.0.2",
 		"graphql": "15.5.0",
-		"houdini": "^0.8.5",
-		"houdini-common": "^0.8.5",
+		"houdini": "^0.8.6-rc.0",
+		"houdini-common": "^0.8.6-rc.0",
 		"mkdirp": "^1.0.4",
 		"prettier": "*",
 		"prettier-plugin-svelte": "^2.1.1",

--- a/packages/houdini-preprocess/src/transforms/fragment.test.ts
+++ b/packages/houdini-preprocess/src/transforms/fragment.test.ts
@@ -1,5 +1,4 @@
 // local imports
-import fragmentProcessor from './fragment'
 import { preprocessorTest } from '../utils'
 import '../../../../jest.setup'
 

--- a/packages/houdini-preprocess/src/transforms/fragment.test.ts
+++ b/packages/houdini-preprocess/src/transforms/fragment.test.ts
@@ -20,7 +20,6 @@ describe('fragment preprocessor', function () {
 		// make sure we added the right stuff
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import _TestFragmentArtifact from "$houdini/artifacts/TestFragment";
-		import { houdiniConfig } from "$houdini";
 		let reference;
 
 		const data = fragment({

--- a/packages/houdini-preprocess/src/transforms/fragment.test.ts
+++ b/packages/houdini-preprocess/src/transforms/fragment.test.ts
@@ -20,11 +20,13 @@ describe('fragment preprocessor', function () {
 		// make sure we added the right stuff
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import _TestFragmentArtifact from "$houdini/artifacts/TestFragment";
+		import { houdiniConfig } from "$houdini";
 		let reference;
 
 		const data = fragment({
 		    "kind": "HoudiniFragment",
-		    "artifact": _TestFragmentArtifact
+		    "artifact": _TestFragmentArtifact,
+		    "config": houdiniConfig
 		}, reference);
 	`)
 	})

--- a/packages/houdini-preprocess/src/transforms/fragment.ts
+++ b/packages/houdini-preprocess/src/transforms/fragment.ts
@@ -21,8 +21,20 @@ export default async function fragmentProcessor(
 		return
 	}
 
-	// make sure we import the config
-	ensureImports(config, doc.instance.content.body, ['houdiniConfig'])
+	// make sure there is a module script
+	if (!doc.module) {
+		doc.module = {
+			start: 0,
+			end: 0,
+			// @ts-ignore
+			content: AST.program([]),
+		}
+	}
+	if (!doc.module) {
+		throw new Error('type script!!')
+	}
+	// add the imports if they're not there
+	ensureImports(config, doc.module.content.body, ['houdiniConfig'])
 
 	// go to every graphql document
 	await walkTaggedDocuments(config, doc, doc.instance.content, {

--- a/packages/houdini-preprocess/src/transforms/fragment.ts
+++ b/packages/houdini-preprocess/src/transforms/fragment.ts
@@ -3,7 +3,7 @@ import * as graphql from 'graphql'
 import * as recast from 'recast'
 import { Config } from 'houdini-common'
 // locals
-import { walkTaggedDocuments, artifactImport, artifactIdentifier } from '../utils'
+import { walkTaggedDocuments, artifactImport, artifactIdentifier, ensureImports } from '../utils'
 import { TransformDocument } from '../types'
 
 const AST = recast.types.builders
@@ -20,6 +20,9 @@ export default async function fragmentProcessor(
 	if (!doc.instance) {
 		return
 	}
+
+	// make sure we import the config
+	ensureImports(config, doc.instance.content.body, ['houdiniConfig'])
 
 	// go to every graphql document
 	await walkTaggedDocuments(config, doc, doc.instance.content, {
@@ -41,6 +44,7 @@ export default async function fragmentProcessor(
 				AST.objectExpression([
 					AST.objectProperty(AST.stringLiteral('kind'), AST.stringLiteral(artifact.kind)),
 					AST.objectProperty(AST.literal('artifact'), AST.identifier(artifactVariable)),
+					AST.objectProperty(AST.literal('config'), AST.identifier('houdiniConfig')),
 				])
 			)
 

--- a/packages/houdini-preprocess/src/transforms/fragment.ts
+++ b/packages/houdini-preprocess/src/transforms/fragment.ts
@@ -20,22 +20,6 @@ export default async function fragmentProcessor(
 	if (!doc.instance) {
 		return
 	}
-
-	// make sure there is a module script
-	if (!doc.module) {
-		doc.module = {
-			start: 0,
-			end: 0,
-			// @ts-ignore
-			content: AST.program([]),
-		}
-	}
-	if (!doc.module) {
-		throw new Error('type script!!')
-	}
-	// add the imports if they're not there
-	ensureImports(config, doc.module.content.body, ['houdiniConfig'])
-
 	// go to every graphql document
 	await walkTaggedDocuments(config, doc, doc.instance.content, {
 		// with only one definition defining a fragment
@@ -46,7 +30,7 @@ export default async function fragmentProcessor(
 				tag.definitions[0].kind === graphql.Kind.FRAGMENT_DEFINITION
 			)
 		},
-		// we want to replace it with an object that the runtime can use
+		// if we found a tag we want to replace it with an object that the runtime can use
 		async onTag({ artifact, node }) {
 			// the local identifier for the artifact
 			const artifactVariable = artifactIdentifier(artifact)

--- a/packages/houdini-preprocess/src/transforms/mutation.test.ts
+++ b/packages/houdini-preprocess/src/transforms/mutation.test.ts
@@ -21,11 +21,13 @@ describe('mutation preprocessor', function () {
 		// make sure we added the right stuff
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import _AddUserArtifact from "$houdini/artifacts/AddUser";
+		import { houdiniConfig } from "$houdini";
 		import { mutation } from "$houdini";
 
 		const data = mutation({
 		    "kind": "HoudiniMutation",
-		    "artifact": _AddUserArtifact
+		    "artifact": _AddUserArtifact,
+		    "config": houdiniConfig
 		});
 	`)
 	})

--- a/packages/houdini-preprocess/src/transforms/mutation.test.ts
+++ b/packages/houdini-preprocess/src/transforms/mutation.test.ts
@@ -21,7 +21,6 @@ describe('mutation preprocessor', function () {
 		// make sure we added the right stuff
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import _AddUserArtifact from "$houdini/artifacts/AddUser";
-		import { houdiniConfig } from "$houdini";
 		import { mutation } from "$houdini";
 
 		const data = mutation({

--- a/packages/houdini-preprocess/src/transforms/mutation.ts
+++ b/packages/houdini-preprocess/src/transforms/mutation.ts
@@ -16,21 +16,6 @@ export default async function mutationProcessor(
 		return
 	}
 
-	// make sure there is a module script
-	if (!doc.module) {
-		doc.module = {
-			start: 0,
-			end: 0,
-			// @ts-ignore
-			content: AST.program([]),
-		}
-	}
-	if (!doc.module) {
-		throw new Error('type script!!')
-	}
-	// add the imports if they're not there
-	ensureImports(config, doc.module.content.body, ['houdiniConfig'])
-
 	// go to every graphql document
 	await walkTaggedDocuments(config, doc, doc.instance.content, {
 		// with only one definition defining a fragment
@@ -42,7 +27,8 @@ export default async function mutationProcessor(
 				graphqlDoc.definitions[0].operation === 'mutation'
 			)
 		},
-		// we want to replace it with an object that the runtime can use
+		// if we found a tag in the document we want to replace it with an object
+		// that the runtime can use
 		onTag({ artifact, node }) {
 			// replace the graphql node with the object
 			node.replaceWith(

--- a/packages/houdini-preprocess/src/transforms/mutation.ts
+++ b/packages/houdini-preprocess/src/transforms/mutation.ts
@@ -4,7 +4,7 @@ import * as graphql from 'graphql'
 import { Config } from 'houdini-common'
 // locals
 import { TransformDocument } from '../types'
-import { walkTaggedDocuments, artifactImport, artifactIdentifier } from '../utils/index'
+import { walkTaggedDocuments, artifactImport, artifactIdentifier, ensureImports } from '../utils'
 const AST = recast.types.builders
 
 export default async function mutationProcessor(
@@ -15,6 +15,9 @@ export default async function mutationProcessor(
 	if (!doc.instance) {
 		return
 	}
+
+	// make sure we import the config
+	ensureImports(config, doc.instance.content.body, ['houdiniConfig'])
 
 	// go to every graphql document
 	await walkTaggedDocuments(config, doc, doc.instance.content, {
@@ -36,6 +39,10 @@ export default async function mutationProcessor(
 					AST.objectProperty(
 						AST.literal('artifact'),
 						AST.identifier(artifactIdentifier(artifact))
+					),
+					AST.objectProperty(
+						AST.stringLiteral('config'),
+						AST.identifier('houdiniConfig')
 					),
 				])
 			)

--- a/packages/houdini-preprocess/src/transforms/mutation.ts
+++ b/packages/houdini-preprocess/src/transforms/mutation.ts
@@ -16,8 +16,20 @@ export default async function mutationProcessor(
 		return
 	}
 
-	// make sure we import the config
-	ensureImports(config, doc.instance.content.body, ['houdiniConfig'])
+	// make sure there is a module script
+	if (!doc.module) {
+		doc.module = {
+			start: 0,
+			end: 0,
+			// @ts-ignore
+			content: AST.program([]),
+		}
+	}
+	if (!doc.module) {
+		throw new Error('type script!!')
+	}
+	// add the imports if they're not there
+	ensureImports(config, doc.module.content.body, ['houdiniConfig'])
 
 	// go to every graphql document
 	await walkTaggedDocuments(config, doc, doc.instance.content, {

--- a/packages/houdini-preprocess/src/transforms/query.test.ts
+++ b/packages/houdini-preprocess/src/transforms/query.test.ts
@@ -21,7 +21,7 @@ describe('query preprocessor', function () {
 		// make sure we added the right stuff
 		expect(doc.module?.content).toMatchInlineSnapshot(`
 		import { convertKitPayload } from "$houdini";
-		import { fetchQuery, RequestContext } from "$houdini";
+		import { fetchQuery, RequestContext, houdiniConfig } from "$houdini";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
 
 		export async function load(context) {
@@ -103,7 +103,7 @@ describe('query preprocessor', function () {
 		// make sure we added the right stuff
 		expect(doc.module?.content).toMatchInlineSnapshot(`
 		import { convertKitPayload } from "$houdini";
-		import { fetchQuery, RequestContext } from "$houdini";
+		import { fetchQuery, RequestContext, houdiniConfig } from "$houdini";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
 
 		export function TestQueryVariables(page) {
@@ -116,6 +116,7 @@ describe('query preprocessor', function () {
 		    const _houdini_context = new RequestContext(context);
 
 		    const _TestQuery_Input = _houdini_context.computeInput({
+		        "config": houdiniConfig,
 		        "mode": "sapper",
 		        "variableFunction": TestQueryVariables,
 		        "artifact": _TestQueryArtifact
@@ -191,7 +192,7 @@ describe('query preprocessor', function () {
 
 		// make sure we added the right stuff
 		expect(doc.module?.content).toMatchInlineSnapshot(`
-		import { fetchQuery, RequestContext } from "$houdini";
+		import { fetchQuery, RequestContext, houdiniConfig } from "$houdini";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
 
 		export async function load(context) {

--- a/packages/houdini-preprocess/src/transforms/query.test.ts
+++ b/packages/houdini-preprocess/src/transforms/query.test.ts
@@ -293,6 +293,7 @@ describe('query preprocessor', function () {
 		    data
 		} = componentQuery({
 		    queryHandler: _TestQuery_handler,
+		    config: houdiniConfig,
 		    artifact: _TestQueryArtifact,
 		    variableFunction: null,
 		    getProps: () => $$props
@@ -340,6 +341,7 @@ describe('query preprocessor', function () {
 		    data
 		} = componentQuery({
 		    queryHandler: _TestQuery_handler,
+		    config: houdiniConfig,
 		    artifact: _TestQueryArtifact,
 		    variableFunction: null,
 		    getProps: () => $$props
@@ -387,6 +389,7 @@ describe('query preprocessor', function () {
 		    data
 		} = componentQuery({
 		    queryHandler: _TestQuery_handler,
+		    config: houdiniConfig,
 		    artifact: _TestQueryArtifact,
 		    variableFunction: TestQueryVariables,
 		    getProps: () => $$props
@@ -434,6 +437,7 @@ describe('query preprocessor', function () {
 		    data
 		} = componentQuery({
 		    queryHandler: _TestQuery_handler,
+		    config: houdiniConfig,
 		    artifact: _TestQueryArtifact,
 		    variableFunction: null,
 		    getProps: () => $$props

--- a/packages/houdini-preprocess/src/transforms/query.test.ts
+++ b/packages/houdini-preprocess/src/transforms/query.test.ts
@@ -21,8 +21,9 @@ describe('query preprocessor', function () {
 		// make sure we added the right stuff
 		expect(doc.module?.content).toMatchInlineSnapshot(`
 		import { convertKitPayload } from "$houdini";
-		import { fetchQuery, RequestContext, houdiniConfig } from "$houdini";
+		import { fetchQuery, RequestContext } from "$houdini";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
+		import { houdiniConfig } from "$houdini";
 
 		export async function load(context) {
 		    const _houdini_context = new RequestContext(context);
@@ -56,7 +57,6 @@ describe('query preprocessor', function () {
 	`)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { routeQuery, componentQuery, query } from "$houdini";
-		import { houdiniConfig } from "$houdini";
 		export let _TestQuery = undefined;
 		export let _TestQuery_Input = undefined;
 
@@ -105,8 +105,9 @@ describe('query preprocessor', function () {
 		// make sure we added the right stuff
 		expect(doc.module?.content).toMatchInlineSnapshot(`
 		import { convertKitPayload } from "$houdini";
-		import { fetchQuery, RequestContext, houdiniConfig } from "$houdini";
+		import { fetchQuery, RequestContext } from "$houdini";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
+		import { houdiniConfig } from "$houdini";
 
 		export function TestQueryVariables(page) {
 		    return {
@@ -152,7 +153,6 @@ describe('query preprocessor', function () {
 	`)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { routeQuery, componentQuery, query } from "$houdini";
-		import { houdiniConfig } from "$houdini";
 		export let _TestQuery = undefined;
 		export let _TestQuery_Input = undefined;
 
@@ -196,8 +196,9 @@ describe('query preprocessor', function () {
 
 		// make sure we added the right stuff
 		expect(doc.module?.content).toMatchInlineSnapshot(`
-		import { fetchQuery, RequestContext, houdiniConfig } from "$houdini";
+		import { fetchQuery, RequestContext } from "$houdini";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
+		import { houdiniConfig } from "$houdini";
 
 		export async function load(context) {
 		    const _houdini_context = new RequestContext(context);
@@ -227,7 +228,6 @@ describe('query preprocessor', function () {
 	`)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { routeQuery, componentQuery, query } from "$houdini";
-		import { houdiniConfig } from "$houdini";
 		export let _TestQuery = undefined;
 		export let _TestQuery_Input = undefined;
 
@@ -273,11 +273,12 @@ describe('query preprocessor', function () {
 		)
 
 		// make sure we added the right stuff
-		expect(doc.module?.content).toMatchInlineSnapshot(``)
+		expect(doc.module?.content).toMatchInlineSnapshot(
+			`import { houdiniConfig } from "$houdini";`
+		)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { routeQuery, componentQuery, query } from "$houdini";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
-		import { houdiniConfig } from "$houdini";
 		export let _TestQuery = undefined;
 		export let _TestQuery_Input = undefined;
 
@@ -321,11 +322,12 @@ describe('query preprocessor', function () {
 		)
 
 		// make sure we added the right stuff
-		expect(doc.module?.content).toMatchInlineSnapshot(``)
+		expect(doc.module?.content).toMatchInlineSnapshot(
+			`import { houdiniConfig } from "$houdini";`
+		)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { routeQuery, componentQuery, query } from "$houdini";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
-		import { houdiniConfig } from "$houdini";
 		export let _TestQuery = undefined;
 		export let _TestQuery_Input = undefined;
 
@@ -369,11 +371,12 @@ describe('query preprocessor', function () {
 		)
 
 		// make sure we added the right stuff
-		expect(doc.module?.content).toMatchInlineSnapshot(``)
+		expect(doc.module?.content).toMatchInlineSnapshot(
+			`import { houdiniConfig } from "$houdini";`
+		)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { routeQuery, componentQuery, query } from "$houdini";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
-		import { houdiniConfig } from "$houdini";
 		export let _TestQuery = undefined;
 		export let _TestQuery_Input = undefined;
 
@@ -417,11 +420,12 @@ describe('query preprocessor', function () {
 		)
 
 		// make sure we added the right stuff
-		expect(doc.module?.content).toMatchInlineSnapshot(``)
+		expect(doc.module?.content).toMatchInlineSnapshot(
+			`import { houdiniConfig } from "$houdini";`
+		)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { routeQuery, componentQuery, query } from "$houdini";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
-		import { houdiniConfig } from "$houdini";
 		export let _TestQuery = undefined;
 		export let _TestQuery_Input = undefined;
 

--- a/packages/houdini-preprocess/src/transforms/query.test.ts
+++ b/packages/houdini-preprocess/src/transforms/query.test.ts
@@ -114,7 +114,12 @@ describe('query preprocessor', function () {
 
 		export async function load(context) {
 		    const _houdini_context = new RequestContext(context);
-		    const _TestQuery_Input = _houdini_context.computeInput("sapper", TestQueryVariables);
+
+		    const _TestQuery_Input = _houdini_context.computeInput({
+		        "mode": "sapper",
+		        "variableFunction": TestQueryVariables,
+		        "artifact": _TestQueryArtifact
+		    });
 
 		    if (!_houdini_context.continue) {
 		        return _houdini_context.returnValue;

--- a/packages/houdini-preprocess/src/transforms/query.test.ts
+++ b/packages/houdini-preprocess/src/transforms/query.test.ts
@@ -56,10 +56,12 @@ describe('query preprocessor', function () {
 	`)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { routeQuery, componentQuery, query } from "$houdini";
+		import { houdiniConfig } from "$houdini";
 		export let _TestQuery = undefined;
 		export let _TestQuery_Input = undefined;
 
 		let _TestQuery_handler = query({
+		    "config": houdiniConfig,
 		    "initialValue": _TestQuery,
 		    "variables": _TestQuery_Input,
 		    "kind": "HoudiniQuery",
@@ -150,10 +152,12 @@ describe('query preprocessor', function () {
 	`)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { routeQuery, componentQuery, query } from "$houdini";
+		import { houdiniConfig } from "$houdini";
 		export let _TestQuery = undefined;
 		export let _TestQuery_Input = undefined;
 
 		let _TestQuery_handler = query({
+		    "config": houdiniConfig,
 		    "initialValue": _TestQuery,
 		    "variables": _TestQuery_Input,
 		    "kind": "HoudiniQuery",
@@ -223,10 +227,12 @@ describe('query preprocessor', function () {
 	`)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { routeQuery, componentQuery, query } from "$houdini";
+		import { houdiniConfig } from "$houdini";
 		export let _TestQuery = undefined;
 		export let _TestQuery_Input = undefined;
 
 		let _TestQuery_handler = query({
+		    "config": houdiniConfig,
 		    "initialValue": _TestQuery,
 		    "variables": _TestQuery_Input,
 		    "kind": "HoudiniQuery",
@@ -271,10 +277,12 @@ describe('query preprocessor', function () {
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { routeQuery, componentQuery, query } from "$houdini";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
+		import { houdiniConfig } from "$houdini";
 		export let _TestQuery = undefined;
 		export let _TestQuery_Input = undefined;
 
 		let _TestQuery_handler = query({
+		    "config": houdiniConfig,
 		    "initialValue": _TestQuery,
 		    "variables": _TestQuery_Input,
 		    "kind": "HoudiniQuery",
@@ -316,10 +324,12 @@ describe('query preprocessor', function () {
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { routeQuery, componentQuery, query } from "$houdini";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
+		import { houdiniConfig } from "$houdini";
 		export let _TestQuery = undefined;
 		export let _TestQuery_Input = undefined;
 
 		let _TestQuery_handler = query({
+		    "config": houdiniConfig,
 		    "initialValue": _TestQuery,
 		    "variables": _TestQuery_Input,
 		    "kind": "HoudiniQuery",
@@ -361,10 +371,12 @@ describe('query preprocessor', function () {
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { routeQuery, componentQuery, query } from "$houdini";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
+		import { houdiniConfig } from "$houdini";
 		export let _TestQuery = undefined;
 		export let _TestQuery_Input = undefined;
 
 		let _TestQuery_handler = query({
+		    "config": houdiniConfig,
 		    "initialValue": _TestQuery,
 		    "variables": _TestQuery_Input,
 		    "kind": "HoudiniQuery",
@@ -406,10 +418,12 @@ describe('query preprocessor', function () {
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { routeQuery, componentQuery, query } from "$houdini";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
+		import { houdiniConfig } from "$houdini";
 		export let _TestQuery = undefined;
 		export let _TestQuery_Input = undefined;
 
 		let _TestQuery_handler = query({
+		    "config": houdiniConfig,
 		    "initialValue": _TestQuery,
 		    "variables": _TestQuery_Input,
 		    "kind": "HoudiniQuery",

--- a/packages/houdini-preprocess/src/transforms/query.ts
+++ b/packages/houdini-preprocess/src/transforms/query.ts
@@ -159,7 +159,7 @@ function processModule(config: Config, script: Script, queries: EmbeddedGraphqlD
 	}
 
 	// add the imports if they're not there
-	ensureImports(config, script.content.body, ['fetchQuery', 'RequestContext'])
+	ensureImports(config, script.content.body, ['fetchQuery', 'RequestContext', 'houdiniConfig'])
 
 	// add the kit preload function
 	addKitLoad(config, script.content.body, queries)
@@ -373,6 +373,10 @@ function addKitLoad(config: Config, body: Statement[], queries: EmbeddedGraphqlD
 								),
 								[
 									AST.objectExpression([
+										AST.objectProperty(
+											AST.literal('config'),
+											AST.identifier('houdiniConfig')
+										),
 										AST.objectProperty(
 											AST.literal('mode'),
 											AST.stringLiteral(config.framework)

--- a/packages/houdini-preprocess/src/transforms/query.ts
+++ b/packages/houdini-preprocess/src/transforms/query.ts
@@ -84,6 +84,10 @@ export default async function queryProcessor(
 					  AST.objectExpression([
 							AST.objectProperty(AST.identifier('queryHandler'), handlerIdentifier),
 							AST.objectProperty(
+								AST.identifier('config'),
+								AST.identifier('houdiniConfig')
+							),
+							AST.objectProperty(
 								AST.identifier('artifact'),
 								AST.identifier(artifactIdentifier(artifact))
 							),

--- a/packages/houdini-preprocess/src/transforms/query.ts
+++ b/packages/houdini-preprocess/src/transforms/query.ts
@@ -139,7 +139,7 @@ export default async function queryProcessor(
 	// add the imports if they're not there
 	ensureImports(config, doc.module.content.body, ['houdiniConfig'])
 
-	// if we are procesing a route, use those processors
+	// if we are processing a route, use those processors
 	if (isRoute) {
 		processModule(config, doc.module, queries)
 	} else {

--- a/packages/houdini-preprocess/src/transforms/query.ts
+++ b/packages/houdini-preprocess/src/transforms/query.ts
@@ -372,8 +372,22 @@ function addKitLoad(config: Config, body: Statement[], queries: EmbeddedGraphqlD
 									AST.identifier('computeInput')
 								),
 								[
-									AST.stringLiteral(config.framework),
-									AST.identifier(queryInputFunction(document.artifact.name)),
+									AST.objectExpression([
+										AST.objectProperty(
+											AST.literal('mode'),
+											AST.stringLiteral(config.framework)
+										),
+										AST.objectProperty(
+											AST.literal('variableFunction'),
+											AST.identifier(
+												queryInputFunction(document.artifact.name)
+											)
+										),
+										AST.objectProperty(
+											AST.literal('artifact'),
+											AST.identifier(artifactIdentifier(document.artifact))
+										),
+									]),
 								]
 						  )
 						: AST.objectExpression([])

--- a/packages/houdini-preprocess/src/transforms/query.ts
+++ b/packages/houdini-preprocess/src/transforms/query.ts
@@ -136,6 +136,9 @@ export default async function queryProcessor(
 		throw new Error('type script!!')
 	}
 
+	// add the imports if they're not there
+	ensureImports(config, doc.module.content.body, ['houdiniConfig'])
+
 	// if we are procesing a route, use those processors
 	if (isRoute) {
 		processModule(config, doc.module, queries)
@@ -145,8 +148,6 @@ export default async function queryProcessor(
 		for (const document of queries) {
 			doc.instance.content.body.unshift(artifactImport(config, document.artifact))
 		}
-		// add the imports if they're not there
-		ensureImports(config, doc.instance.content.body, ['houdiniConfig'])
 	}
 	processInstance(config, isRoute, doc.instance, queries)
 }
@@ -165,7 +166,7 @@ function processModule(config: Config, script: Script, queries: EmbeddedGraphqlD
 	}
 
 	// add the imports if they're not there
-	ensureImports(config, script.content.body, ['fetchQuery', 'RequestContext', 'houdiniConfig'])
+	ensureImports(config, script.content.body, ['fetchQuery', 'RequestContext'])
 
 	// add the kit preload function
 	addKitLoad(config, script.content.body, queries)

--- a/packages/houdini-preprocess/src/transforms/query.ts
+++ b/packages/houdini-preprocess/src/transforms/query.ts
@@ -132,16 +132,9 @@ export default async function queryProcessor(
 		}
 	}
 
-	if (!doc.module) {
-		throw new Error('type script!!')
-	}
-
-	// add the imports if they're not there
-	ensureImports(config, doc.module.content.body, ['houdiniConfig'])
-
 	// if we are processing a route, use those processors
 	if (isRoute) {
-		processModule(config, doc.module, queries)
+		processModule(config, doc.module!, queries)
 	} else {
 		// we need to make sure to import all of the artifacts in the instance script
 		// every document will need to be imported

--- a/packages/houdini-preprocess/src/transforms/query.ts
+++ b/packages/houdini-preprocess/src/transforms/query.ts
@@ -141,6 +141,8 @@ export default async function queryProcessor(
 		for (const document of queries) {
 			doc.instance.content.body.unshift(artifactImport(config, document.artifact))
 		}
+		// add the imports if they're not there
+		ensureImports(config, doc.instance.content.body, ['houdiniConfig'])
 	}
 	processInstance(config, isRoute, doc.instance, queries)
 }
@@ -224,6 +226,10 @@ function processInstance(
 					queryHandlerIdentifier(operation),
 					AST.callExpression(AST.identifier('query'), [
 						AST.objectExpression([
+							AST.objectProperty(
+								AST.stringLiteral('config'),
+								AST.identifier('houdiniConfig')
+							),
 							AST.objectProperty(
 								AST.stringLiteral('initialValue'),
 								AST.identifier(

--- a/packages/houdini-preprocess/src/transforms/subscription.test.ts
+++ b/packages/houdini-preprocess/src/transforms/subscription.test.ts
@@ -21,7 +21,6 @@ describe('subscription preprocessor', function () {
 		// make sure we added the right stuff
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import _TestSubscriptionArtifact from "$houdini/artifacts/TestSubscription";
-		import { houdiniConfig } from "$houdini";
 
 		const data = subscription({
 		    "kind": "HoudiniSubscription",

--- a/packages/houdini-preprocess/src/transforms/subscription.test.ts
+++ b/packages/houdini-preprocess/src/transforms/subscription.test.ts
@@ -21,10 +21,12 @@ describe('subscription preprocessor', function () {
 		// make sure we added the right stuff
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import _TestSubscriptionArtifact from "$houdini/artifacts/TestSubscription";
+		import { houdiniConfig } from "$houdini";
 
 		const data = subscription({
 		    "kind": "HoudiniSubscription",
-		    "artifact": _TestSubscriptionArtifact
+		    "artifact": _TestSubscriptionArtifact,
+		    "config": houdiniConfig
 		}, variables);
 	`)
 	})

--- a/packages/houdini-preprocess/src/transforms/subscription.ts
+++ b/packages/houdini-preprocess/src/transforms/subscription.ts
@@ -3,7 +3,7 @@ import * as graphql from 'graphql'
 import * as recast from 'recast'
 import { Config } from 'houdini-common'
 // locals
-import { walkTaggedDocuments, artifactIdentifier } from '../utils/index'
+import { walkTaggedDocuments, artifactIdentifier, ensureImports } from '../utils'
 import { TransformDocument } from '../types'
 
 const AST = recast.types.builders
@@ -20,6 +20,9 @@ export default async function subscriptionProcessor(
 	if (!doc.instance) {
 		return
 	}
+
+	// make sure we import the config
+	ensureImports(config, doc.instance.content.body, ['houdiniConfig'])
 
 	// go to every graphql document
 	await walkTaggedDocuments(config, doc, doc.instance.content, {
@@ -42,6 +45,7 @@ export default async function subscriptionProcessor(
 				AST.objectExpression([
 					AST.objectProperty(AST.stringLiteral('kind'), AST.stringLiteral(artifact.kind)),
 					AST.objectProperty(AST.literal('artifact'), AST.identifier(artifactVariable)),
+					AST.objectProperty(AST.literal('config'), AST.identifier('houdiniConfig')),
 				])
 			)
 

--- a/packages/houdini-preprocess/src/transforms/subscription.ts
+++ b/packages/houdini-preprocess/src/transforms/subscription.ts
@@ -21,8 +21,11 @@ export default async function subscriptionProcessor(
 		return
 	}
 
-	// make sure we import the config
-	ensureImports(config, doc.instance.content.body, ['houdiniConfig'])
+	if (!doc.module) {
+		throw new Error('type script!!')
+	}
+	// add the imports if they're not there
+	ensureImports(config, doc.module.content.body, ['houdiniConfig'])
 
 	// go to every graphql document
 	await walkTaggedDocuments(config, doc, doc.instance.content, {

--- a/packages/houdini-preprocess/src/transforms/subscription.ts
+++ b/packages/houdini-preprocess/src/transforms/subscription.ts
@@ -21,12 +21,6 @@ export default async function subscriptionProcessor(
 		return
 	}
 
-	if (!doc.module) {
-		throw new Error('type script!!')
-	}
-	// add the imports if they're not there
-	ensureImports(config, doc.module.content.body, ['houdiniConfig'])
-
 	// go to every graphql document
 	await walkTaggedDocuments(config, doc, doc.instance.content, {
 		// with only one definition defining a subscription

--- a/packages/houdini/cmd/generators/artifacts/artifacts.test.ts
+++ b/packages/houdini/cmd/generators/artifacts/artifacts.test.ts
@@ -2261,9 +2261,7 @@ test('custom scalar shows up in artifact', async function () {
 			DateTime: {
 				type: 'Date',
 				unmarshal(val: number): Date {
-					const date = new Date(0)
-					date.setMilliseconds(val)
-					return date
+					return new Date(val)
 				},
 				marshal(date: Date): number {
 					return date.getTime()

--- a/packages/houdini/cmd/generators/artifacts/artifacts.test.ts
+++ b/packages/houdini/cmd/generators/artifacts/artifacts.test.ts
@@ -1862,6 +1862,14 @@ describe('mutation artifacts', function () {
 		                }
 		            }
 		        }
+		    },
+
+		    input: {
+		        "fields": {
+		            "value": "String"
+		        },
+
+		        "types": {}
 		    }
 		};
 	`)
@@ -2125,6 +2133,14 @@ describe('mutation artifacts', function () {
 		                }
 		            }
 		        }
+		    },
+
+		    input: {
+		        "fields": {
+		            "value": "String"
+		        },
+
+		        "types": {}
 		    }
 		};
 	`)
@@ -2214,6 +2230,14 @@ describe('mutation artifacts', function () {
 		                }
 		            }
 		        }
+		    },
+
+		    input: {
+		        "fields": {
+		            "value": "String"
+		        },
+
+		        "types": {}
 		    }
 		};
 	`)
@@ -2289,6 +2313,134 @@ test('custom scalar shows up in artifact', async function () {
 		                    "type": "DateTime",
 		                    "keyRaw": "createdAt"
 		                }
+		            }
+		        }
+		    }
+		};
+	`)
+})
+
+test('operation inputs', async function () {
+	// the config to use in tests
+	const localConfig = testConfig({
+		schema: `
+		enum MyEnum { 
+			Hello
+		}
+		
+		input UserFilter {
+			middle: NestedUserFilter
+			listRequired: [String!]!
+			nullList: [String]
+			recursive: UserFilter
+			enum: MyEnum
+		}
+
+		input NestedUserFilter {
+			id: ID!
+			firstName: String!
+			admin: Boolean
+			age: Int
+			weight: Float
+		}
+
+		type User { 
+			id: ID!
+		}
+
+		type Query {
+			user(id: ID, filter: UserFilter, filterList: [UserFilter!], enumArg: MyEnum): User
+		}
+	`,
+	})
+
+	// execute the generator
+	await runPipeline(localConfig, [
+		mockCollectedDoc(
+			'TestQuery',
+			`
+			query TestQuery(
+				$id: ID, 
+				$filter: UserFilter, 
+				$filterList: [UserFilter!], 
+				$enumArg: MyEnum
+			) { 
+				user(
+					id: $id,
+					filter: $filter,
+					filterList: $filterList,
+					enumArg: $enumArg,
+				) {
+					id 
+				} 
+			}
+			`
+		),
+	])
+
+	// load the contents of the file
+	const queryContents = await fs.readFile(
+		path.join(config.artifactPath(docs[0].document)),
+		'utf-8'
+	)
+	expect(queryContents).toBeTruthy()
+	// parse the contents
+	const parsedQuery: ProgramKind = recast.parse(queryContents, {
+		parser: typeScriptParser,
+	}).program
+	// verify contents
+	expect(parsedQuery).toMatchInlineSnapshot(`
+		module.exports = {
+		    name: "TestQuery",
+		    kind: "HoudiniQuery",
+		    hash: "d8d2089cd5e3dd8793db526f8cdb3be2",
+
+		    raw: \`query TestQuery($id: ID, $filter: UserFilter, $filterList: [UserFilter!], $enumArg: MyEnum) {
+		  user(id: $id, filter: $filter, filterList: $filterList, enumArg: $enumArg) {
+		    id
+		  }
+		}
+		\`,
+
+		    rootType: "Query",
+
+		    selection: {
+		        "user": {
+		            "type": "User",
+		            "keyRaw": "user(id: $id, filter: $filter, filterList: $filterList, enumArg: $enumArg)",
+
+		            "fields": {
+		                "id": {
+		                    "type": "ID",
+		                    "keyRaw": "id"
+		                }
+		            }
+		        }
+		    },
+
+		    input: {
+		        "fields": {
+		            "id": "ID",
+		            "filter": "UserFilter",
+		            "filterList": "UserFilter",
+		            "enumArg": "MyEnum"
+		        },
+
+		        "types": {
+		            "NestedUserFilter": {
+		                "id": "ID",
+		                "firstName": "String",
+		                "admin": "Boolean",
+		                "age": "Int",
+		                "weight": "Float"
+		            },
+
+		            "UserFilter": {
+		                "middle": "NestedUserFilter",
+		                "listRequired": "String",
+		                "nullList": "String",
+		                "recursive": "UserFilter",
+		                "enum": "MyEnum"
 		            }
 		        }
 		    }

--- a/packages/houdini/cmd/generators/artifacts/index.ts
+++ b/packages/houdini/cmd/generators/artifacts/index.ts
@@ -15,6 +15,7 @@ import { moduleExport, writeFile } from '../../utils'
 import selection from './selection'
 import { operationsByPath, FilterMap } from './operations'
 import writeIndexFile from './indexFile'
+import { inputObject } from './inputs'
 
 const AST = recast.types.builders
 
@@ -210,6 +211,15 @@ export default async function artifactGenerator(config: Config, docs: CollectedG
 						})
 					)
 				)
+
+				// if there are inputs to the operation
+				const inputs = operations[0]?.variableDefinitions
+				// add the input type definition to the artifact
+				if (inputs && inputs.length > 0) {
+					artifact.properties.push(
+						AST.objectProperty(AST.identifier('input'), inputObject(config, inputs))
+					)
+				}
 
 				// the artifact should be the default export of the file
 				const file = AST.program([moduleExport(config, 'default', artifact)])

--- a/packages/houdini/cmd/generators/artifacts/inputs.ts
+++ b/packages/houdini/cmd/generators/artifacts/inputs.ts
@@ -1,0 +1,96 @@
+// externals
+import * as recast from 'recast'
+import * as graphql from 'graphql'
+import { Config } from 'houdini-common'
+import { unwrapType } from '../../utils'
+
+const AST = recast.types.builders
+
+type ObjectProperty = recast.types.namedTypes.ObjectProperty
+type ObjectExpression = recast.types.namedTypes.ObjectExpression
+
+export function inputObject(
+	config: Config,
+	inputs: readonly graphql.VariableDefinitionNode[]
+): ObjectExpression {
+	// inputs can be recursive so we can't flatten the input type into a single object
+
+	// there will always be an object that maps the root inputs to their type
+	const properties: ObjectProperty[] = [
+		AST.objectProperty(
+			AST.literal('fields'),
+			AST.objectExpression(
+				inputs.map((input) => {
+					// find the inner type
+					const { type } = unwrapType(config, input.type)
+
+					// embed the type in the input
+					return AST.objectProperty(
+						AST.literal(input.variable.name.value),
+						AST.stringLiteral(type.name)
+					)
+				})
+			)
+		),
+	]
+
+	// make sure we don't define the same input type
+	const visitedTypes = new Set<string>()
+
+	const typeObjectProperties: ObjectProperty[] = []
+	for (const input of inputs) {
+		walkInputs(config, visitedTypes, typeObjectProperties, input.type)
+	}
+	properties.push(
+		AST.objectProperty(AST.literal('types'), AST.objectExpression(typeObjectProperties))
+	)
+
+	return AST.objectExpression(properties)
+}
+
+function walkInputs(
+	config: Config,
+	visitedTypes: Set<string>,
+	properties: ObjectProperty[],
+	rootType: graphql.TypeNode | graphql.GraphQLNamedType
+) {
+	// find the core type
+	const { type } = unwrapType(config, rootType)
+
+	// if we've seen this type already
+	if (visitedTypes.has(type.name)) {
+		// don't do anything else
+		return
+	}
+
+	// if this is a scalar or enum then we don't need to add anything to the type object
+	if (graphql.isEnumType(type) || graphql.isScalarType(type)) {
+		return
+	}
+	if (graphql.isUnionType(type)) {
+		return
+	}
+
+	// we haven't seen this type before and are about to generate the type
+	visitedTypes.add(type.name)
+
+	// generate the entry for the type
+	properties.push(
+		AST.objectProperty(
+			AST.literal(type.name),
+			AST.objectExpression(
+				Object.values(type.getFields()).map((field: graphql.GraphQLInputField) => {
+					const { type: fieldType } = unwrapType(config, field.type)
+
+					// keep walking down
+					walkInputs(config, visitedTypes, properties, fieldType)
+
+					return AST.objectProperty(
+						AST.literal(field.name),
+						AST.stringLiteral(fieldType.toString())
+					)
+				})
+			)
+		)
+	)
+}

--- a/packages/houdini/cmd/generators/runtime/copyRuntime.test.ts
+++ b/packages/houdini/cmd/generators/runtime/copyRuntime.test.ts
@@ -29,7 +29,7 @@ test('cache index runtime imports config file - commonjs', async function () {
 		var config = require('../../../../../config.cjs');
 		Object.defineProperty(exports, "__esModule", { value: true });
 		var cache_1 = require("./cache");
-		// @ts-ignore
+		// @ts-ignore: config will be defined by the generator
 		exports.default = new cache_1.Cache(config);
 	`)
 })
@@ -53,7 +53,7 @@ test('cache index runtime imports config file - kit', async function () {
 	expect(parsedQuery).toMatchInlineSnapshot(`
 		import config from "../../../config.cjs"
 		import { Cache } from './cache';
-		// @ts-ignore
+		// @ts-ignore: config will be defined by the generator
 		export default new Cache(config);
 	`)
 })

--- a/packages/houdini/cmd/generators/runtime/copyRuntime.test.ts
+++ b/packages/houdini/cmd/generators/runtime/copyRuntime.test.ts
@@ -1,0 +1,59 @@
+// external imports
+import path from 'path'
+import { testConfig } from 'houdini-common'
+import fs from 'fs/promises'
+import * as typeScriptParser from 'recast/parsers/typescript'
+import { ProgramKind } from 'ast-types/gen/kinds'
+import * as recast from 'recast'
+// local imports
+import '../../../../../jest.setup'
+import { runPipeline } from '../../generate'
+
+test('cache index runtime imports config file - commonjs', async function () {
+	const config = testConfig({ mode: 'sapper' })
+	// execute the generator
+	await runPipeline(config, [])
+
+	// open up the index file
+	const fileContents = await fs.readFile(
+		path.join(config.runtimeDirectory, 'cache', 'index.js'),
+		'utf-8'
+	)
+	expect(fileContents).toBeTruthy()
+	// parse the contents
+	const parsedQuery: ProgramKind = recast.parse(fileContents, {
+		parser: typeScriptParser,
+	}).program
+	// verify contents
+	expect(parsedQuery).toMatchInlineSnapshot(`
+		var config = require('../../../../../config.cjs');
+		Object.defineProperty(exports, "__esModule", { value: true });
+		var cache_1 = require("./cache");
+		// @ts-ignore
+		exports.default = new cache_1.Cache(config);
+	`)
+})
+
+test('cache index runtime imports config file - kit', async function () {
+	const config = testConfig({ mode: 'kit' })
+	// execute the generator
+	await runPipeline(config, [])
+
+	// open up the index file
+	const fileContents = await fs.readFile(
+		path.join(config.runtimeDirectory, 'cache', 'index.js'),
+		'utf-8'
+	)
+	expect(fileContents).toBeTruthy()
+	// parse the contents
+	const parsedQuery: ProgramKind = recast.parse(fileContents, {
+		parser: typeScriptParser,
+	}).program
+	// verify contents
+	expect(parsedQuery).toMatchInlineSnapshot(`
+		import config from "../../../config.cjs"
+		import { Cache } from './cache';
+		// @ts-ignore
+		export default new Cache(config);
+	`)
+})

--- a/packages/houdini/cmd/generators/runtime/copyRuntime.ts
+++ b/packages/houdini/cmd/generators/runtime/copyRuntime.ts
@@ -11,6 +11,13 @@ import { writeFile } from '../../utils'
 // @ts-ignore
 const currentDir = global.__dirname || dirname(fileURLToPath(import.meta.url))
 
+// TODO: find a better way of handling this. The runtime needs to be able to import the config file
+// 		 to support features like custom scalars. In order to pull this off, this generator
+//       copies the compiled runtime and then manually adds an import to the config file.
+//       The runtime index file already exports the config file but for some reason vite
+//       can't find the exported value when it comes from inside. It has no problem
+//       finding the config reference exported from $houdini from the preprocessor 🤷
+
 export default async function runtimeGenerator(config: Config, docs: CollectedGraphQLDocument[]) {
 	// when running in the real world, scripts are nested in a sub directory of build, in tests they aren't nested
 	// under /src so we need to figure out how far up to go to find the appropriately compiled runtime

--- a/packages/houdini/cmd/generators/runtime/copyRuntime.ts
+++ b/packages/houdini/cmd/generators/runtime/copyRuntime.ts
@@ -11,13 +11,6 @@ import { writeFile } from '../../utils'
 // @ts-ignore
 const currentDir = global.__dirname || dirname(fileURLToPath(import.meta.url))
 
-// TODO: find a better way of handling this. The runtime needs to be able to import the config file
-// 		 to support features like custom scalars. In order to pull this off, this generator
-//       copies the compiled runtime and then manually adds an import to the config file.
-//       The runtime index file already exports the config file but for some reason vite
-//       can't find the exported value when it comes from inside. It has no problem
-//       finding the config reference exported from $houdini from the preprocessor 🤷
-
 export default async function runtimeGenerator(config: Config, docs: CollectedGraphQLDocument[]) {
 	// when running in the real world, scripts are nested in a sub directory of build, in tests they aren't nested
 	// under /src so we need to figure out how far up to go to find the appropriately compiled runtime
@@ -33,27 +26,10 @@ export default async function runtimeGenerator(config: Config, docs: CollectedGr
 	)
 
 	// copy the compiled source code to the target directory
-	await recursiveCopy(source, config.runtimeDirectory)
-
-	// the path from the cache's index file to the config file
-	const cacheIndex = path.join(config.runtimeDirectory, 'cache', 'index.js')
-	const relativePath = path.relative(cacheIndex, config.filepath).slice('../'.length)
-
-	// read the cache file
-	const cacheIndexContents = await fs.readFile(cacheIndex, 'utf-8')
-
-	// define the local variable that the runtime uses to thread the config to the cache constructor
-	const newContents =
-		(config.module === 'esm'
-			? `import config from "${relativePath}"\n`
-			: `var config = require('${relativePath}');`) +
-		cacheIndexContents.replace('"use strict";', '')
-
-	// write the new cache index
-	await writeFile(cacheIndex, newContents)
+	await recursiveCopy(config, source, config.runtimeDirectory)
 }
 
-async function recursiveCopy(source: string, target: string, notRoot?: boolean) {
+async function recursiveCopy(config: Config, source: string, target: string, notRoot?: boolean) {
 	// if the folder containing the target doesn't exist, then we need to create it
 	let parentDir = path.join(target, path.basename(source))
 	// if we are at the root, then go up one
@@ -75,16 +51,42 @@ async function recursiveCopy(source: string, target: string, notRoot?: boolean) 
 				// figure out the full path of the source
 				const childPath = path.join(source, child)
 
+				// TODO: find a better way of handling this. The runtime needs to be able to import the config file
+				//       to support features like custom scalars. In order to pull this off, this generator
+				//       copies the compiled runtime and then manually adds an import to the config file.
+				//       The runtime index file already exports the config file but for some reason vite
+				//       can't find the exported value when it comes from inside. It has no problem
+				//       finding the config reference exported from $houdini from the preprocessor 🤷
+				const isCacheIndex =
+					source.substring(source.lastIndexOf('/') + 1) === 'cache' &&
+					child === 'index.js'
+				const cacheIndexPath = path.join(config.runtimeDirectory, 'cache', 'index.js')
+
 				// if the child is a directory
 				if ((await fs.lstat(childPath)).isDirectory()) {
 					// keep walking down
-					await recursiveCopy(childPath, parentDir, true)
+					await recursiveCopy(config, childPath, parentDir, true)
 				}
 				// the child is a file, copy it to the parent directory
 				else {
 					const targetPath = path.join(parentDir, child)
 
-					await writeFile(targetPath, await fs.readFile(childPath, 'utf-8'))
+					let contents = await fs.readFile(childPath, 'utf-8')
+
+					// if we are writing to the cache index file, modify the contents
+					if (isCacheIndex) {
+						const relativePath = path
+							.relative(cacheIndexPath, config.filepath)
+							.slice('../'.length)
+
+						contents =
+							(config.module === 'esm'
+								? `import config from "${relativePath}"\n`
+								: `var config = require('${relativePath}');`) +
+							contents.replace('"use strict";', '')
+					}
+
+					await writeFile(targetPath, contents)
 				}
 			})
 		)

--- a/packages/houdini/cmd/generators/runtime/indexFile.test.ts
+++ b/packages/houdini/cmd/generators/runtime/indexFile.test.ts
@@ -69,7 +69,7 @@ test('runtime index file - kit', async function () {
 	}).program
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		export {default as houdiniConfig } from "../config.cjs"
+		export { default as houdiniConfig } from "../config.cjs"
 		export * from "./runtime"
 		export * from "./artifacts"
 	`)

--- a/packages/houdini/cmd/generators/runtime/indexFile.test.ts
+++ b/packages/houdini/cmd/generators/runtime/indexFile.test.ts
@@ -69,7 +69,7 @@ test('runtime index file - kit', async function () {
 	}).program
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		export { default as houdiniConfig } from "../config.cjs"
+		export {default as houdiniConfig } from "../config.cjs"
 		export * from "./runtime"
 		export * from "./artifacts"
 	`)

--- a/packages/houdini/cmd/generators/runtime/indexFile.test.ts
+++ b/packages/houdini/cmd/generators/runtime/indexFile.test.ts
@@ -47,6 +47,9 @@ test('runtime index file - sapper', async function () {
 		};
 		Object.defineProperty(exports, "__esModule", { value: true });
 
+		var config = require("../../../config.cjs");
+		Object.defineProperty(exports, "config", { enumerable: true, get: function () { return __importDefault(config).default; } });
+
 		__exportStar(require("./runtime"), exports);
 		__exportStar(require("./artifacts"), exports);
 	`)
@@ -69,7 +72,8 @@ test('runtime index file - kit', async function () {
 	}).program
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		export * from "./runtime";
-		export * from "./artifacts";
+		export {default as config } from "../config.cjs"
+		export * from "./runtime"
+		export * from "./artifacts"
 	`)
 })

--- a/packages/houdini/cmd/generators/runtime/indexFile.test.ts
+++ b/packages/houdini/cmd/generators/runtime/indexFile.test.ts
@@ -47,8 +47,8 @@ test('runtime index file - sapper', async function () {
 		};
 		Object.defineProperty(exports, "__esModule", { value: true });
 
-		var config = require("../../../config.cjs");
-		Object.defineProperty(exports, "config", { enumerable: true, get: function () { return __importDefault(config).default; } });
+		var houdiniConfig = require("../../../config.cjs");
+		Object.defineProperty(exports, "houdiniConfig", { enumerable: true, get: function () { return __importDefault(houdiniConfig).default; } });
 
 		__exportStar(require("./runtime"), exports);
 		__exportStar(require("./artifacts"), exports);
@@ -60,9 +60,6 @@ test('runtime index file - kit', async function () {
 	// execute the generator
 	await runPipeline(config, docs)
 
-	// look up the files in the artifact directory
-	const files = await fs.readdir(config.artifactDirectory)
-
 	// open up the index file
 	const queryContents = await fs.readFile(path.join(config.rootDir, 'index.js'), 'utf-8')
 	expect(queryContents).toBeTruthy()
@@ -72,7 +69,7 @@ test('runtime index file - kit', async function () {
 	}).program
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		export {default as config } from "../config.cjs"
+		export {default as houdiniConfig } from "../config.cjs"
 		export * from "./runtime"
 		export * from "./artifacts"
 	`)

--- a/packages/houdini/cmd/generators/runtime/indexFile.ts
+++ b/packages/houdini/cmd/generators/runtime/indexFile.ts
@@ -18,7 +18,7 @@ export default async function writeIndexFile(config: Config, docs: CollectedGrap
 	if (config.module === 'commonjs') {
 		body = `${cjsIndexFilePreamble}
 
-${exportDefaultFrom(configPath, 'config')}
+${exportDefaultFrom(configPath, 'houdiniConfig')}
 
 ${exportStarFrom(runtimeDir)}
 ${exportStarFrom(artifactDir)}
@@ -27,7 +27,7 @@ ${exportStarFrom(artifactDir)}
 	// otherwise just use esm statements as the final result
 	else {
 		body = `
-export {default as config } from "${configPath}"
+export {default as houdiniConfig } from "${configPath}"
 export * from "${runtimeDir}"
 export * from "${artifactDir}"
 `

--- a/packages/houdini/cmd/generators/typescript/inlineType.ts
+++ b/packages/houdini/cmd/generators/typescript/inlineType.ts
@@ -34,7 +34,7 @@ export function inlineType({
 	let result: TSTypeKind
 	// if we are looking at a scalar field
 	if (graphql.isScalarType(type)) {
-		result = scalarPropertyValue(type as graphql.GraphQLNamedType)
+		result = scalarPropertyValue(config, type as graphql.GraphQLNamedType)
 	}
 	// we could have encountered an enum
 	else if (graphql.isEnumType(type)) {

--- a/packages/houdini/cmd/generators/typescript/typeReference.ts
+++ b/packages/houdini/cmd/generators/typescript/typeReference.ts
@@ -20,7 +20,7 @@ export function tsTypeReference(
 	let result
 	// if we're looking at a scalar
 	if (graphql.isScalarType(type)) {
-		result = scalarPropertyValue(type)
+		result = scalarPropertyValue(config, type)
 	}
 	// we're looking at an object
 	else {

--- a/packages/houdini/cmd/generators/typescript/typescript.test.ts
+++ b/packages/houdini/cmd/generators/typescript/typescript.test.ts
@@ -754,10 +754,7 @@ describe('typescript', function () {
 				DateTime: {
 					type: 'Date',
 					unmarshal(val: number): Date {
-						const date = new Date(0)
-						date.setMilliseconds(val)
-
-						return date
+						return new Date(val)
 					},
 					marshal(date: Date): number {
 						return date.getTime()
@@ -813,10 +810,7 @@ describe('typescript', function () {
 				DateTime: {
 					type: 'Date',
 					unmarshal(val: number): Date {
-						const date = new Date(0)
-						date.setMilliseconds(val)
-
-						return date
+						return new Date(val)
 					},
 					marshal(date: Date): number {
 						return date.getTime()

--- a/packages/houdini/cmd/init.ts
+++ b/packages/houdini/cmd/init.ts
@@ -132,7 +132,7 @@ const configFile = ({
 }) => {
 	// the actual config contents
 	const configObj = `{
-		schemaPath: path.resolve('${schemaPath}'),
+		schemaPath: '${schemaPath}',
 		sourceGlob: 'src/**/*.svelte',
 		module: '${module}',
 		framework: '${framework}',
@@ -141,13 +141,9 @@ const configFile = ({
 
 	return module === 'esm'
 		? // SvelteKit default config
-		  `import path from 'path'
-
-export default ${configObj}
+		  `export default ${configObj}
 `
 		: // sapper default config
-		  `const path = require('path')
-
-module.exports = ${configObj}
+		  `module.exports = ${configObj}
 `
 }

--- a/packages/houdini/cmd/utils/index.ts
+++ b/packages/houdini/cmd/utils/index.ts
@@ -1,4 +1,4 @@
-export { default as moduleExport } from './moduleExport'
+export * from './moduleExport'
 export * from './commonjs'
 export * from './writeFile'
 export * from './graphql'

--- a/packages/houdini/cmd/utils/moduleExport.ts
+++ b/packages/houdini/cmd/utils/moduleExport.ts
@@ -4,7 +4,7 @@ import { Config } from 'houdini-common'
 
 const AST = recast.types.builders
 
-export default function moduleExport(config: Config, key: string, value: ExpressionKind) {
+export function moduleExport(config: Config, key: string, value: ExpressionKind) {
 	// module exports in sapper should be common js
 	if (config.module === 'commonjs') {
 		// the thing to assign

--- a/packages/houdini/package-lock.json
+++ b/packages/houdini/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini",
-	"version": "0.8.5",
+	"version": "0.8.6-rc.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/houdini/package.json
+++ b/packages/houdini/package.json
@@ -6,7 +6,7 @@
 		"build:runtime": "npm run build:runtime:cjs && npm run build:runtime:esm",
 		"build:runtime:cjs": "tsc --p tsconfig.runtime.cjs.json",
 		"build:runtime:esm": "tsc --p tsconfig.runtime.esm.json",
-		"build:cmd": "npm run build:cmd:main && npm run build:cmd:tsc",
+		"build:cmd": "npm run build:cmd:tsc && npm run build:cmd:main",
 		"build:cmd:main": "TARGET=esm WHICH=cmd rollup --config ./rollup.config.js && ./typeModule.sh",
 		"build:cmd:tsc": "tsc --p tsconfig.json",
 		"build": "npm run build:runtime && npm run build:cmd",

--- a/packages/houdini/package.json
+++ b/packages/houdini/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini",
-	"version": "0.8.5",
+	"version": "0.8.6-rc.0",
 	"description": "",
 	"scripts": {
 		"build:runtime": "npm run build:runtime:cjs && npm run build:runtime:esm",
@@ -42,7 +42,7 @@
 		"estree-walker": "^2.0.2",
 		"glob": "^7.1.6",
 		"graphql": "^15.5.0",
-		"houdini-common": "^0.8.5",
+		"houdini-common": "^0.8.6-rc.0",
 		"inquirer": "^7.3.3",
 		"mkdirp": "^1.0.4",
 		"node-fetch": "^2.6.1",

--- a/packages/houdini/rollup.config.js
+++ b/packages/houdini/rollup.config.js
@@ -29,7 +29,7 @@ export default {
 		format: TARGET === 'esm' ? 'esm' : 'cjs',
 		exports: 'named',
 	},
-	external: ['graphql', './adapter.mjs'],
+	external: ['graphql', './adapter.mjs', '$houdini'],
 	plugins: [
 		preserveShebangs(),
 		json(),

--- a/packages/houdini/runtime/cache/cache.test.ts
+++ b/packages/houdini/runtime/cache/cache.test.ts
@@ -1,10 +1,14 @@
+// external imports
+import { testConfig } from 'houdini-common'
 // locals
 import { Cache } from './cache'
 import { SubscriptionSelection } from '../types'
 
+const config = testConfig()
+
 test('save root object', function () {
 	// instantiate a cache we'll test against
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	// save the data
 	const data = {
@@ -43,7 +47,7 @@ test('save root object', function () {
 
 test('partial update existing record', function () {
 	// instantiate a cache we'll test against
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	// save the data
 	cache.write(
@@ -108,7 +112,7 @@ test('partial update existing record', function () {
 
 test('linked records with updates', function () {
 	// instantiate a cache we'll test against
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	// save the data
 	cache.write(
@@ -232,7 +236,7 @@ test('linked records with updates', function () {
 
 test('linked lists', function () {
 	// instantiate the cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	// add some data to the cache
 	cache.write(
@@ -304,7 +308,7 @@ test('linked lists', function () {
 
 test('list as value with args', function () {
 	// instantiate the cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	// add some data to the cache
 	cache.write(
@@ -346,7 +350,7 @@ test('list as value with args', function () {
 
 test('root subscribe - field change', function () {
 	// instantiate a cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	const selection = {
 		viewer: {
@@ -416,7 +420,7 @@ test('root subscribe - field change', function () {
 
 test('root subscribe - linked object changed', function () {
 	// instantiate a cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	const selection = {
 		viewer: {
@@ -493,7 +497,7 @@ test('root subscribe - linked object changed', function () {
 
 test('root subscribe - linked list lost entry', function () {
 	// instantiate a cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	const selection = {
 		viewer: {
@@ -590,7 +594,7 @@ test('root subscribe - linked list lost entry', function () {
 
 test('root subscribe - linked list reorder', function () {
 	// instantiate a cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	const selection = {
 		viewer: {
@@ -697,7 +701,7 @@ test('root subscribe - linked list reorder', function () {
 
 test('unsubscribe', function () {
 	// instantiate a cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	const selection = {
 		viewer: {
@@ -759,7 +763,7 @@ test('unsubscribe', function () {
 
 test('append in connection', function () {
 	// instantiate a cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	const selection = {
 		viewer: {
@@ -845,7 +849,7 @@ test('append in connection', function () {
 
 test('prepend in connection', function () {
 	// instantiate a cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	const selection = {
 		viewer: {
@@ -931,7 +935,7 @@ test('prepend in connection', function () {
 
 test('connection filter - must_not positive', function () {
 	// instantiate a cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	const selection: SubscriptionSelection = {
 		viewer: {
@@ -1029,7 +1033,7 @@ test('connection filter - must_not positive', function () {
 
 test('connection filter - must_not negative', function () {
 	// instantiate a cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	const selection: SubscriptionSelection = {
 		viewer: {
@@ -1113,7 +1117,7 @@ test('connection filter - must_not negative', function () {
 
 test('connection filter - must positive', function () {
 	// instantiate a cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	const selection: SubscriptionSelection = {
 		viewer: {
@@ -1211,7 +1215,7 @@ test('connection filter - must positive', function () {
 
 test('connection filter - must negative', function () {
 	// instantiate a cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	const selection: SubscriptionSelection = {
 		viewer: {
@@ -1295,7 +1299,7 @@ test('connection filter - must negative', function () {
 
 test('subscribe to new connection nodes', function () {
 	// instantiate a cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	const selection = {
 		viewer: {
@@ -1403,7 +1407,7 @@ test('subscribe to new connection nodes', function () {
 
 test('remove from connection', function () {
 	// instantiate a cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	const selection = {
 		viewer: {
@@ -1482,7 +1486,7 @@ test('remove from connection', function () {
 
 test('delete node', function () {
 	// instantiate a cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	const selection = {
 		viewer: {
@@ -1560,7 +1564,7 @@ test('delete node', function () {
 
 test('append operation', function () {
 	// instantiate a cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	// create a connection we will add to
 	cache.write(
@@ -1650,7 +1654,7 @@ test('append operation', function () {
 
 test('append when operation', function () {
 	// instantiate a cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	// create a connection we will add to
 	cache.write(
@@ -1751,7 +1755,7 @@ test('append when operation', function () {
 
 test('prepend when operation', function () {
 	// instantiate a cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	// create a connection we will add to
 	cache.write(
@@ -1853,7 +1857,7 @@ test('prepend when operation', function () {
 
 test('prepend operation', function () {
 	// instantiate a cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	// create a connection we will add to
 	cache.write(
@@ -1966,7 +1970,7 @@ test('prepend operation', function () {
 
 test('remove operation', function () {
 	// instantiate a cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	// create a connection we will add to
 	cache.write(
@@ -2071,7 +2075,7 @@ test('remove operation', function () {
 
 test('delete operation', function () {
 	// instantiate a cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	// create a connection we will add to
 	cache.write(
@@ -2174,7 +2178,7 @@ test('delete operation', function () {
 
 test('variables in query and subscription', function () {
 	// instantiate a cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	const selection = {
 		viewer: {
@@ -2285,7 +2289,7 @@ test('variables in query and subscription', function () {
 
 test('deleting a node removes nested subscriptions', function () {
 	// instantiate a cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	const selection = {
 		viewer: {
@@ -2350,7 +2354,7 @@ test('deleting a node removes nested subscriptions', function () {
 
 test('same record twice in a query survives one unsubscribe (reference counting)', function () {
 	// instantiate a cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	const selection = {
 		viewer: {
@@ -2431,7 +2435,7 @@ test('same record twice in a query survives one unsubscribe (reference counting)
 
 test('embedded references', function () {
 	// instantiate a cache
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	const selection = {
 		viewer: {
@@ -2590,7 +2594,7 @@ describe('key evaluation', function () {
 
 	for (const row of table) {
 		test(row.title, function () {
-			const cache = new Cache()
+			const cache = new Cache(config)
 
 			expect(cache.internal.evaluateKey(row.key, row.variables)).toEqual(row.expected)
 		})
@@ -2599,7 +2603,7 @@ describe('key evaluation', function () {
 
 test('writing abstract objects', function () {
 	// instantiate a cache we'll test against
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	// save the data
 	const data = {
@@ -2645,7 +2649,7 @@ test('writing abstract objects', function () {
 
 test('writing abstract lists', function () {
 	// instantiate a cache we'll test against
-	const cache = new Cache()
+	const cache = new Cache(config)
 
 	// save the data
 	const data = {

--- a/packages/houdini/runtime/cache/cache.ts
+++ b/packages/houdini/runtime/cache/cache.ts
@@ -4,6 +4,7 @@ import type { Config } from 'houdini-common'
 import { Maybe, GraphQLValue, SubscriptionSelection, SubscriptionSpec } from '../types'
 import { Record } from './record'
 import { ConnectionHandler } from './connection'
+import { isScalar } from '../scalars'
 
 // this class implements the cache that drives houdini queries
 export class Cache {
@@ -156,7 +157,7 @@ export class Cache {
 			const linkedList = parent.linkedList(key)
 
 			// if we are looking at a scalar
-			if (this.isScalarLink(type)) {
+			if (isScalar(this._config, type)) {
 				// look up the primitive value
 				const val = parent.getField(key)
 
@@ -207,7 +208,7 @@ export class Cache {
 
 			// if the field points to a link, we need to subscribe to any fields of that
 			// linked record
-			if (!this.isScalarLink(type)) {
+			if (!isScalar(this._config, type)) {
 				// if the link points to a record then we just have to add it to the one
 				const linkedRecord = rootRecord.linkedRecord(key)
 				let children = linkedRecord ? [linkedRecord] : rootRecord.linkedList(key)
@@ -290,7 +291,7 @@ export class Cache {
 
 			// if the field points to a link, we need to remove any subscribers on any fields of that
 			// linked record
-			if (!this.isScalarLink(type)) {
+			if (!isScalar(this._config, type)) {
 				// if the link points to a record then we just have to remove it to the one
 				const linkedRecord = rootRecord.linkedRecord(key)
 				let children = linkedRecord ? [linkedRecord] : rootRecord.linkedList(key)
@@ -398,7 +399,7 @@ export class Cache {
 			}
 
 			// the value could be a list
-			else if (!this.isScalarLink(linkedType) && Array.isArray(value) && fields) {
+			else if (!isScalar(this._config, linkedType) && Array.isArray(value) && fields) {
 				// build up the list of linked ids
 				const linkedIDs: string[] = []
 				// look up the current known link id
@@ -573,12 +574,6 @@ export class Cache {
 		}
 
 		return this._data.get(id) || null
-	}
-
-	private isScalarLink(type: string) {
-		return ['String', 'Boolean', 'Float', 'ID', 'Int']
-			.concat(Object.keys(this._config.scalars || {}))
-			.includes(type)
 	}
 
 	private notifySubscribers(specs: SubscriptionSpec[], variables: {} = {}) {

--- a/packages/houdini/runtime/cache/cache.ts
+++ b/packages/houdini/runtime/cache/cache.ts
@@ -164,10 +164,13 @@ export class Cache {
 				if (this._config.scalars?.[type]?.unmarshal) {
 					// pass the primitive value to the unmarshal function
 					target[attributeName] = this._config.scalars[type].unmarshal(val)
-				} else {
+				}
+				// the field does not have an unmarshal function
+				else {
 					target[attributeName] = val
 				}
 
+				// we're done
 				continue
 			}
 			// the field could be an object
@@ -180,6 +183,10 @@ export class Cache {
 				target[attributeName] = linkedList.map((linkedRecord) =>
 					this.getData(linkedRecord, fields, variables)
 				)
+			}
+			// we don't recognize the field type
+			else {
+				throw new Error('Encountered unknown type: ' + type)
 			}
 		}
 

--- a/packages/houdini/runtime/cache/cache.ts
+++ b/packages/houdini/runtime/cache/cache.ts
@@ -1,3 +1,5 @@
+// external imports
+import type { Config } from 'houdini-common'
 // local imports
 import { Maybe, GraphQLValue, SubscriptionSelection, SubscriptionSpec } from '../types'
 import { Record } from './record'
@@ -5,6 +7,11 @@ import { ConnectionHandler } from './connection'
 
 // this class implements the cache that drives houdini queries
 export class Cache {
+	_config: Config
+	constructor(config: Config) {
+		this._config = config
+	}
+
 	// the map from entity id to record
 	private _data: Map<string | undefined, Record> = new Map()
 	// associate connection names with the handler that wraps the list

--- a/packages/houdini/runtime/cache/index.ts
+++ b/packages/houdini/runtime/cache/index.ts
@@ -1,3 +1,5 @@
 import { Cache } from './cache'
+// @ts-ignore
+import { houdiniConfig } from '..'
 
-export default new Cache()
+export default new Cache(houdiniConfig)

--- a/packages/houdini/runtime/cache/index.ts
+++ b/packages/houdini/runtime/cache/index.ts
@@ -1,4 +1,4 @@
 import { Cache } from './cache'
 
-// @ts-ignore
+// @ts-ignore: config will be defined by the generator
 export default new Cache(config)

--- a/packages/houdini/runtime/cache/index.ts
+++ b/packages/houdini/runtime/cache/index.ts
@@ -1,5 +1,5 @@
 import { Cache } from './cache'
 // @ts-ignore
-import { houdiniConfig } from '../..'
+import { houdiniConfig } from '$houdini'
 
 export default new Cache(houdiniConfig)

--- a/packages/houdini/runtime/cache/index.ts
+++ b/packages/houdini/runtime/cache/index.ts
@@ -1,5 +1,4 @@
 import { Cache } from './cache'
-// @ts-ignore
-import { houdiniConfig } from '$houdini'
 
-export default new Cache(houdiniConfig)
+// @ts-ignore
+export default new Cache(config)

--- a/packages/houdini/runtime/cache/index.ts
+++ b/packages/houdini/runtime/cache/index.ts
@@ -1,5 +1,5 @@
 import { Cache } from './cache'
 // @ts-ignore
-import { houdiniConfig } from '..'
+import { houdiniConfig } from '../..'
 
 export default new Cache(houdiniConfig)

--- a/packages/houdini/runtime/fragment.ts
+++ b/packages/houdini/runtime/fragment.ts
@@ -5,6 +5,7 @@ import { onMount } from 'svelte'
 import type { Fragment, FragmentArtifact, GraphQLTagResult, SubscriptionSpec } from './types'
 import cache from './cache'
 import { getVariables } from './context'
+import { unmarshalSelection } from './scalars'
 
 // fragment returns the requested data from the reference
 export default function fragment<_Fragment extends Fragment<any>>(
@@ -24,11 +25,18 @@ export default function fragment<_Fragment extends Fragment<any>>(
 
 	const queryVariables = getVariables()
 
+	// unmarshal the selection
+	const unmarshaledValue = unmarshalSelection(
+		fragment.config,
+		fragment.artifact.selection,
+		initialValue
+	)
+
 	// wrap the result in a store we can use to keep this query up to date
-	const value = readable(initialValue, (set) => {
+	const value = readable(unmarshaledValue, (set) => {
 		// @ts-ignore: isn't properly typed yet to know if initialValue has
 		// what it needs to compute the id
-		const parentID = cache.id(artifact.rootType, initialValue)
+		const parentID = cache.id(artifact.rootType, unmarshaledValue)
 
 		subscriptionSpec = {
 			rootType: artifact.rootType,

--- a/packages/houdini/runtime/fragment.ts
+++ b/packages/houdini/runtime/fragment.ts
@@ -1,6 +1,7 @@
 // externals
 import { readable, Readable } from 'svelte/store'
 import { onMount } from 'svelte'
+import type { Config } from 'houdini-common'
 // locals
 import type { Fragment, FragmentArtifact, GraphQLTagResult, SubscriptionSpec } from './types'
 import cache from './cache'
@@ -16,28 +17,27 @@ export default function fragment<_Fragment extends Fragment<any>>(
 	if (fragment.kind !== 'HoudiniFragment') {
 		throw new Error('getFragment can only take fragment documents')
 	}
-	// we might get the the artifact nested under default
-	const artifact: FragmentArtifact =
-		// @ts-ignore: typing esm/cjs interop is hard
-		fragment.artifact.default || fragment.artifact
 
-	let subscriptionSpec: SubscriptionSpec | undefined
+	// we might get re-exported values nested under default
+
+	// @ts-ignore: typing esm/cjs interop is hard
+	const artifact: FragmentArtifact = fragment.artifact.default || fragment.artifact
 
 	const queryVariables = getVariables()
 
-	// unmarshal the selection
-	const unmarshaledValue = unmarshalSelection(
-		fragment.config,
-		fragment.artifact.selection,
-		initialValue
+	// @ts-ignore: isn't properly typed yet to know if initialValue has the right values
+	const parentID = cache.id(artifact.rootType, initialValue)
+
+	// load the fragment data from the cache
+	const initialStoreValue = cache.internal.getData(
+		cache.internal.record(parentID),
+		artifact.selection,
+		queryVariables()
 	)
 
+	let subscriptionSpec: SubscriptionSpec | undefined
 	// wrap the result in a store we can use to keep this query up to date
-	const value = readable(unmarshaledValue, (set) => {
-		// @ts-ignore: isn't properly typed yet to know if initialValue has
-		// what it needs to compute the id
-		const parentID = cache.id(artifact.rootType, unmarshaledValue)
-
+	const value = readable(initialStoreValue, (set) => {
 		subscriptionSpec = {
 			rootType: artifact.rootType,
 			selection: artifact.selection,

--- a/packages/houdini/runtime/mutation.ts
+++ b/packages/houdini/runtime/mutation.ts
@@ -3,9 +3,10 @@ import { executeQuery } from './network'
 import { Operation, GraphQLTagResult, MutationArtifact } from './types'
 import cache from './cache'
 import { getVariables } from './context'
+import { marshalInputs } from './scalars'
 
 // @ts-ignore: this file will get generated and does not exist in the source code
-import { getSession, goTo } from './adapter.mjs'
+import { getSession } from './adapter.mjs'
 
 // mutation returns a handler that will send the mutation to the server when
 // invoked
@@ -32,7 +33,11 @@ export default function mutation<_Mutation extends Operation<any, any>>(
 		try {
 			const result = await executeQuery<_Mutation['result']>(
 				artifact,
-				variables,
+				marshalInputs({
+					input: variables,
+					artifact: document.artifact,
+					config: document.config,
+				}),
 				sessionStore
 			)
 

--- a/packages/houdini/runtime/mutation.ts
+++ b/packages/houdini/runtime/mutation.ts
@@ -1,3 +1,5 @@
+// externals
+import type { Config } from 'houdini-common'
 // locals
 import { executeQuery } from './network'
 import { Operation, GraphQLTagResult, MutationArtifact } from './types'
@@ -18,10 +20,12 @@ export default function mutation<_Mutation extends Operation<any, any>>(
 		throw new Error('mutation() must be passed a mutation document')
 	}
 
-	// we might get the the artifact nested under default
-	const artifact: MutationArtifact =
-		// @ts-ignore: typing esm/cjs interop is hard
-		document.artifact.default || document.artifact
+	// we might get re-exported values nested under default
+
+	// @ts-ignore: typing esm/cjs interop is hard
+	const artifact: MutationArtifact = document.artifact.default || document.artifact
+	// @ts-ignore: typing esm/cjs interop is hard
+	const config: Config = document.config.default || document.config
 
 	// grab the session from the adapter
 	const sessionStore = getSession()
@@ -36,7 +40,7 @@ export default function mutation<_Mutation extends Operation<any, any>>(
 				marshalInputs({
 					input: variables,
 					artifact: document.artifact,
-					config: document.config,
+					config: config,
 				}),
 				sessionStore
 			)
@@ -44,7 +48,7 @@ export default function mutation<_Mutation extends Operation<any, any>>(
 			cache.write(artifact.selection, result.data, queryVariables())
 
 			// unmarshal any scalars on the body
-			return unmarshalSelection(document.config, document.artifact.selection, result.data)
+			return unmarshalSelection(config, artifact.selection, result.data)
 		} catch (error) {
 			throw error
 		}

--- a/packages/houdini/runtime/mutation.ts
+++ b/packages/houdini/runtime/mutation.ts
@@ -3,7 +3,7 @@ import { executeQuery } from './network'
 import { Operation, GraphQLTagResult, MutationArtifact } from './types'
 import cache from './cache'
 import { getVariables } from './context'
-import { marshalInputs } from './scalars'
+import { marshalInputs, unmarshalSelection } from './scalars'
 
 // @ts-ignore: this file will get generated and does not exist in the source code
 import { getSession } from './adapter.mjs'
@@ -43,7 +43,8 @@ export default function mutation<_Mutation extends Operation<any, any>>(
 
 			cache.write(artifact.selection, result.data, queryVariables())
 
-			return result.data
+			// unmarshal any scalars on the body
+			return unmarshalSelection(document.config, document.artifact.selection, result.data)
 		} catch (error) {
 			throw error
 		}

--- a/packages/houdini/runtime/mutation.ts
+++ b/packages/houdini/runtime/mutation.ts
@@ -41,7 +41,7 @@ export default function mutation<_Mutation extends Operation<any, any>>(
 					input: variables,
 					artifact: document.artifact,
 					config: config,
-				}),
+				}) as _Mutation['input'],
 				sessionStore
 			)
 

--- a/packages/houdini/runtime/network.ts
+++ b/packages/houdini/runtime/network.ts
@@ -1,5 +1,6 @@
 // externals
 import { get, Readable } from 'svelte/store'
+import type { Config } from 'houdini-common'
 // locals
 import { JSONValue, MutationArtifact, QueryArtifact, SubscriptionArtifact } from './types'
 
@@ -236,6 +237,7 @@ export class RequestContext {
 	// the context
 
 	computeInput({
+		config,
 		mode,
 		variableFunction,
 		artifact,
@@ -243,6 +245,7 @@ export class RequestContext {
 		mode: 'kit' | 'sapper'
 		variableFunction: SapperLoad | KitLoad
 		artifact: QueryArtifact
+		config: Config
 	}) {
 		// if we are in kit mode, just pass the context directly
 		if (mode === 'kit') {

--- a/packages/houdini/runtime/network.ts
+++ b/packages/houdini/runtime/network.ts
@@ -2,7 +2,7 @@
 import { get, Readable } from 'svelte/store'
 import type { Config } from 'houdini-common'
 // locals
-import { JSONValue, MutationArtifact, QueryArtifact, SubscriptionArtifact } from './types'
+import { MutationArtifact, QueryArtifact, SubscriptionArtifact } from './types'
 
 export class Environment {
 	private fetch: RequestHandler<any>
@@ -244,7 +244,7 @@ export class RequestContext {
 	}: {
 		mode: 'kit' | 'sapper'
 		variableFunction: SapperLoad | KitLoad
-		artifact: QueryArtifact
+		artifact: QueryArtifact | MutationArtifact | SubscriptionArtifact
 		config: Config
 	}) {
 		// if we are in kit mode, just pass the context directly
@@ -261,6 +261,6 @@ export class RequestContext {
 type SapperLoad = (
 	page: FetchContext['page'],
 	session: FetchContext['session']
-) => Record<string, JSONValue>
+) => Record<string, any>
 
-type KitLoad = (ctx: FetchContext) => Record<string, JSONValue>
+type KitLoad = (ctx: FetchContext) => Record<string, any>

--- a/packages/houdini/runtime/network.ts
+++ b/packages/houdini/runtime/network.ts
@@ -236,7 +236,6 @@ export class RequestContext {
 	// compute the inputs for an operation should reflect the framework's conventions.
 	// in sapper, this means preparing a `this` for the function. for kit, we can just pass
 	// the context
-
 	computeInput({
 		config,
 		mode,

--- a/packages/houdini/runtime/query.ts
+++ b/packages/houdini/runtime/query.ts
@@ -7,7 +7,7 @@ import { Operation, GraphQLTagResult, SubscriptionSpec, QueryArtifact } from './
 import cache from './cache'
 import { setVariables } from './context'
 import { executeQuery, RequestPayload } from './network'
-import { marshalInputs } from './scalars'
+import { marshalInputs, unmarshalSelection } from './scalars'
 
 // @ts-ignore: this file will get generated and does not exist in the source code
 import { getSession, goTo } from './adapter.mjs'
@@ -33,7 +33,9 @@ export default function query<_Query extends Operation<any, any>>(
 	const initialValue = document.initialValue?.data
 
 	// define the store we will hold the data
-	const store = writable(initialValue)
+	const store = writable(
+		unmarshalSelection(document.config, document.artifact.selection, initialValue)
+	)
 
 	// we might get the the artifact nested under default
 	const artifact: QueryArtifact =

--- a/packages/houdini/runtime/query.ts
+++ b/packages/houdini/runtime/query.ts
@@ -20,6 +20,13 @@ export default function query<_Query extends Operation<any, any>>(
 		throw new Error('query() must be passed a query document')
 	}
 
+	// we might get re-exported values nested under default
+
+	// @ts-ignore: typing esm/cjs interop is hard
+	const artifact: QueryArtifact = document.artifact.default || document.artifact
+	// @ts-ignore: typing esm/cjs interop is hard
+	const config: Config = document.config.default || document.config
+
 	// a query is never 'loading'
 	const loading = writable(false)
 
@@ -33,14 +40,7 @@ export default function query<_Query extends Operation<any, any>>(
 	const initialValue = document.initialValue?.data
 
 	// define the store we will hold the data
-	const store = writable(
-		unmarshalSelection(document.config, document.artifact.selection, initialValue)
-	)
-
-	// we might get the the artifact nested under default
-	const artifact: QueryArtifact =
-		// @ts-ignore: typing esm/cjs interop is hard
-		document.artifact.default || document.artifact
+	const store = writable(unmarshalSelection(config, artifact.selection, initialValue))
 
 	// pull out the writer for internal use
 	let subscriptionSpec: SubscriptionSpec | null = {
@@ -92,7 +92,7 @@ export default function query<_Query extends Operation<any, any>>(
 		variables = newVariables || {}
 
 		// update the local store
-		store.set(newData.data)
+		store.set(unmarshalSelection(config, artifact.selection, newData.data))
 
 		// write the data we received
 		cache.write(artifact.selection, newData.data, variables)

--- a/packages/houdini/runtime/scalars.test.ts
+++ b/packages/houdini/runtime/scalars.test.ts
@@ -41,8 +41,7 @@ const config = testConfig({
 		DateTime: {
 			type: 'Date',
 			unmarshal(val: number): Date {
-				const date = new Date(val)
-				return date
+				return new Date(val)
 			},
 			marshal(date: Date): number {
 				return date.getTime()

--- a/packages/houdini/runtime/scalars.test.ts
+++ b/packages/houdini/runtime/scalars.test.ts
@@ -15,15 +15,19 @@ test('computing inputs marshals custom scalars', function () {
 		schema: `
             scalar DateTime
             
-            input NestedDates { 
+            input NestedDate { 
                 date: DateTime!
-                nested: NestedDates!
+                nested: NestedDate!
             }
 
             type TodoItem { 
                 text: String!
                 createdAt: DateTime! 
             }	
+
+			type Query { 
+				users(date: NestedDate): String
+			}
         `,
 		scalars: {
 			DateTime: {
@@ -49,6 +53,17 @@ test('computing inputs marshals custom scalars', function () {
 		raw: 'does not matter',
 		selection: {},
 		rootType: 'Query',
+		input: {
+			fields: {
+				date: 'NestedDate',
+			},
+			types: {
+				NestedDate: {
+					date: 'Date',
+					nested: 'NestedDate',
+				},
+			},
+		},
 	}
 
 	// some dates to check against

--- a/packages/houdini/runtime/scalars.test.ts
+++ b/packages/houdini/runtime/scalars.test.ts
@@ -1,0 +1,95 @@
+import { testConfig } from 'houdini-common'
+import { RequestContext } from './network'
+import { QueryArtifact } from './types'
+
+test('computing inputs marshals custom scalars', function () {
+	// a mock request context
+	const ctx = new RequestContext({
+		page: { host: '', path: '', params: null, query: null },
+		context: null,
+		session: null,
+		fetch: ((() => {}) as unknown) as (input: RequestInfo, init?: RequestInit) => Promise<any>,
+	})
+
+	const localConfig = testConfig({
+		schema: `
+            scalar DateTime
+            
+            input NestedDates { 
+                date: DateTime!
+                nested: NestedDates!
+            }
+
+            type TodoItem { 
+                text: String!
+                createdAt: DateTime! 
+            }	
+        `,
+		scalars: {
+			DateTime: {
+				type: 'Date',
+				unmarshal(val: number): Date {
+					const date = new Date(0)
+					date.setMilliseconds(val)
+
+					return date
+				},
+				marshal(date: Date): number {
+					return date.getTime()
+				},
+			},
+		},
+	})
+
+	// the test artifact
+	const artifact: QueryArtifact = {
+		name: 'AllItems',
+		kind: 'HoudiniQuery',
+		hash: 'hash',
+		raw: 'does not matter',
+		selection: {},
+		rootType: 'Query',
+	}
+
+	// some dates to check against
+	const date1 = new Date(0)
+	const date2 = new Date(1)
+	const date3 = new Date(2)
+
+	// compute the inputs
+	const inputs = ctx.computeInput({
+		config: localConfig,
+		mode: 'kit',
+		artifact,
+		variableFunction() {
+			return {
+				date: [
+					{
+						date: date1,
+						nested: {
+							date: date2,
+							nested: {
+								date: date3,
+							},
+						},
+					},
+				],
+			}
+		},
+	})
+
+	// make sure we got the expected value
+	expect(inputs).toEqual({
+		date: [
+			{
+				date: date1.getTime(),
+				nested: {
+					date: date2.getTime(),
+					nested: {
+						date: date3.getTime(),
+					},
+				},
+			},
+		],
+	})
+})

--- a/packages/houdini/runtime/scalars.test.ts
+++ b/packages/houdini/runtime/scalars.test.ts
@@ -2,7 +2,7 @@ import { testConfig } from 'houdini-common'
 import { RequestContext } from './network'
 import { QueryArtifact } from './types'
 
-test('computing inputs marshals custom scalars', function () {
+describe('marshal inputs', function () {
 	// a mock request context
 	const ctx = new RequestContext({
 		page: { host: '', path: '', params: null, query: null },
@@ -16,6 +16,7 @@ test('computing inputs marshals custom scalars', function () {
             scalar DateTime
             
             input NestedDate { 
+				name: String
                 date: DateTime!
                 nested: NestedDate!
             }
@@ -59,52 +60,81 @@ test('computing inputs marshals custom scalars', function () {
 			},
 			types: {
 				NestedDate: {
-					date: 'Date',
+					date: 'DateTime',
 					nested: 'NestedDate',
 				},
 			},
 		},
 	}
 
-	// some dates to check against
-	const date1 = new Date(0)
-	const date2 = new Date(1)
-	const date3 = new Date(2)
+	test('lists of objects', function () {
+		// some dates to check against
+		const date1 = new Date(0)
+		const date2 = new Date(1)
+		const date3 = new Date(2)
 
-	// compute the inputs
-	const inputs = ctx.computeInput({
-		config: localConfig,
-		mode: 'kit',
-		artifact,
-		variableFunction() {
-			return {
-				date: [
-					{
-						date: date1,
-						nested: {
-							date: date2,
+		// compute the inputs
+		const inputs = ctx.computeInput({
+			config: localConfig,
+			mode: 'kit',
+			artifact,
+			variableFunction() {
+				return {
+					date: [
+						{
+							date: date1,
 							nested: {
-								date: date3,
+								date: date2,
+								nested: {
+									date: date3,
+								},
 							},
 						},
-					},
-				],
-			}
-		},
-	})
+					],
+				}
+			},
+		})
 
-	// make sure we got the expected value
-	expect(inputs).toEqual({
-		date: [
-			{
-				date: date1.getTime(),
-				nested: {
-					date: date2.getTime(),
+		// make sure we got the expected value
+		expect(inputs).toEqual({
+			date: [
+				{
+					date: date1.getTime(),
 					nested: {
-						date: date3.getTime(),
+						date: date2.getTime(),
+						nested: {
+							date: date3.getTime(),
+						},
 					},
 				},
+			],
+		})
+	})
+
+	test('non-custom scalars', function () {
+		// compute the inputs
+		const inputs = ctx.computeInput({
+			config: localConfig,
+			mode: 'kit',
+			artifact,
+			variableFunction() {
+				return {
+					date: [
+						{
+							name: 'hello',
+						},
+					],
+				}
 			},
-		],
+		})
+
+		// make sure we got the expected value
+		expect(inputs).toEqual({
+			date: [
+				{
+					name: 'hello',
+				},
+			],
+		})
 	})
 })

--- a/packages/houdini/runtime/scalars.test.ts
+++ b/packages/houdini/runtime/scalars.test.ts
@@ -213,6 +213,44 @@ describe('marshal inputs', function () {
 			],
 		})
 	})
+
+	test('null', function () {
+		// compute the inputs
+		const inputs = ctx.computeInput({
+			config,
+			mode: 'kit',
+			artifact,
+			variableFunction() {
+				return {
+					date: null,
+				}
+			},
+		})
+
+		// make sure we got the expected value
+		expect(inputs).toEqual({
+			date: null,
+		})
+	})
+
+	test('undefined', function () {
+		// compute the inputs
+		const inputs = ctx.computeInput({
+			config,
+			mode: 'kit',
+			artifact,
+			variableFunction() {
+				return {
+					date: undefined,
+				}
+			},
+		})
+
+		// make sure we got the expected value
+		expect(inputs).toEqual({
+			date: undefined,
+		})
+	})
 })
 
 describe('unmarshal selection', function () {
@@ -240,6 +278,54 @@ describe('unmarshal selection', function () {
 					},
 				},
 			],
+		})
+	})
+
+	test('undefined', function () {
+		const data = {
+			item: undefined,
+		}
+
+		const selection = {
+			item: {
+				type: 'TodoItem',
+				keyRaw: 'item',
+
+				fields: {
+					createdAt: {
+						type: 'DateTime',
+						keyRaw: 'createdAt',
+					},
+				},
+			},
+		}
+
+		expect(unmarshalSelection(config, selection, data)).toEqual({
+			item: undefined,
+		})
+	})
+
+	test('null', function () {
+		const data = {
+			item: null,
+		}
+
+		const selection = {
+			item: {
+				type: 'TodoItem',
+				keyRaw: 'item',
+
+				fields: {
+					createdAt: {
+						type: 'DateTime',
+						keyRaw: 'createdAt',
+					},
+				},
+			},
+		}
+
+		expect(unmarshalSelection(config, selection, data)).toEqual({
+			item: null,
 		})
 	})
 

--- a/packages/houdini/runtime/scalars.test.ts
+++ b/packages/houdini/runtime/scalars.test.ts
@@ -27,7 +27,7 @@ describe('marshal inputs', function () {
             }	
 
 			type Query { 
-				users(date: NestedDate): String
+				users(date: NestedDate, booleanValue: Boolean): String
 			}
         `,
 		scalars: {
@@ -57,6 +57,7 @@ describe('marshal inputs', function () {
 		input: {
 			fields: {
 				date: 'NestedDate',
+				booleanValue: 'Boolean',
 			},
 			types: {
 				NestedDate: {
@@ -111,7 +112,49 @@ describe('marshal inputs', function () {
 		})
 	})
 
-	test('non-custom scalars', function () {
+	test('root fields', function () {
+		// compute the inputs
+		const inputs = ctx.computeInput({
+			config: localConfig,
+			mode: 'kit',
+			artifact,
+			variableFunction() {
+				return {
+					booleanValue: true,
+				}
+			},
+		})
+
+		// make sure we got the expected value
+		expect(inputs).toEqual({
+			booleanValue: true,
+		})
+	})
+
+	test('non-custom scalar fields of objects', function () {
+		// compute the inputs
+		const inputs = ctx.computeInput({
+			config: localConfig,
+			mode: 'kit',
+			artifact,
+			variableFunction() {
+				return {
+					date: {
+						name: 'hello',
+					},
+				}
+			},
+		})
+
+		// make sure we got the expected value
+		expect(inputs).toEqual({
+			date: {
+				name: 'hello',
+			},
+		})
+	})
+
+	test('non-custom scalar fields of lists', function () {
 		// compute the inputs
 		const inputs = ctx.computeInput({
 			config: localConfig,

--- a/packages/houdini/runtime/scalars.ts
+++ b/packages/houdini/runtime/scalars.ts
@@ -1,0 +1,1 @@
+export function foo() {}

--- a/packages/houdini/runtime/scalars.ts
+++ b/packages/houdini/runtime/scalars.ts
@@ -1,7 +1,12 @@
 // externals
 import type { Config } from 'houdini-common'
 // locals
-import { MutationArtifact, QueryArtifact, SubscriptionArtifact } from './types'
+import {
+	MutationArtifact,
+	QueryArtifact,
+	SubscriptionArtifact,
+	SubscriptionSelection,
+} from './types'
 
 export function marshalInputs<T>({
 	artifact,
@@ -44,7 +49,7 @@ export function marshalInputs<T>({
 			}
 
 			// if the type doesn't require marshaling and isn't a referenced type
-			if (!artifact.input?.types[type]) {
+			if (isScalar(config, type)) {
 				return [fieldName, value]
 			}
 
@@ -52,4 +57,57 @@ export function marshalInputs<T>({
 			return [fieldName, marshalInputs({ artifact, config, input: value, rootType: type })]
 		})
 	)
+}
+
+export function unmarshalSelection(
+	config: Config,
+	selection: SubscriptionSelection,
+	data: unknown
+): {} {
+	// if we are looking at a list
+	if (Array.isArray(data)) {
+		// unmarshal every entry in the list
+		return data.map((val) => unmarshalSelection(config, selection, val))
+	}
+
+	// we're looking at an object, build it up from the current input
+	return Object.fromEntries(
+		Object.entries(data as {}).map(([fieldName, value]) => {
+			// look up the type for the field
+			const { type, fields } = selection[fieldName]
+			// if we don't have type information for this field, just use it directly
+			// it's most likely a non-custom scalars or enums
+			if (!type) {
+				return [fieldName, value]
+			}
+
+			// is the type something that requires marshaling
+			if (config.scalars?.[type]?.marshal) {
+				return [fieldName, config.scalars[type].unmarshal(value)]
+			}
+
+			// if the type doesn't require marshaling and isn't a referenced type
+			// if the type is a scalar that doesn't require marshaling
+			if (isScalar(config, type)) {
+				return [fieldName, value]
+			}
+
+			if (fields) {
+				return [
+					fieldName,
+					// unmarshalSelection({ artifact, config, input: value, rootType: type }),
+					unmarshalSelection(config, fields, value),
+				]
+			}
+
+			return []
+		})
+	)
+}
+
+// we can't use config.isScalar because that would require bundling in houdini-common
+export function isScalar(config: Config, type: string) {
+	return ['String', 'Boolean', 'Float', 'ID', 'Int']
+		.concat(Object.keys(config.scalars || {}))
+		.includes(type)
 }

--- a/packages/houdini/runtime/scalars.ts
+++ b/packages/houdini/runtime/scalars.ts
@@ -7,11 +7,46 @@ export function marshalInputs({
 	artifact,
 	config,
 	input,
+	rootType = '@root',
 }: {
 	artifact: QueryArtifact | MutationArtifact | SubscriptionArtifact
 	config: Config
-	input: {}
+	input: unknown
+	rootType: string
 }) {
-	console.log(config, artifact.input)
+	// if there are no inputs in the object, nothing to do
+	if (!artifact.input) {
+		return input
+	}
+
+	// the object containing the relevant fields
+	const fields = rootType === '@root' ? artifact.input.fields : artifact.input.types[rootType]
+
+	// if we are looking at a list
+	if (Array.isArray(input)) {
+		return input.map((val) => marshalInputs({ artifact, config, input: val, rootType }))
+	}
+
+	// we're looking at an object, build it up from the current input
+	return Object.fromEntries(
+		Object.entries(input as {}).map(([fieldName, value]) => {
+			// look up the type for the field
+			const type = fields[fieldName]
+			// if we don't have type information for this field, just use it directly
+			// it's most likely a non-custom scalars or enums
+			if (!type) {
+				return [fieldName, value]
+			}
+
+			// is the type something that requires marshals
+			if (config.scalars?.[type]?.marshal) {
+				return [fieldName, config.scalars[type].marshal(value)]
+			}
+
+			// we ran into an object type that should be referenced by the artifact
+			return [fieldName, marshalInputs({ artifact, config, input: value, rootType: type })]
+		})
+	)
+
 	return input
 }

--- a/packages/houdini/runtime/scalars.ts
+++ b/packages/houdini/runtime/scalars.ts
@@ -38,9 +38,14 @@ export function marshalInputs<T>({
 				return [fieldName, value]
 			}
 
-			// is the type something that requires marshals
+			// is the type something that requires marshaling
 			if (config.scalars?.[type]?.marshal) {
 				return [fieldName, config.scalars[type].marshal(value)]
+			}
+
+			// if the type doesn't require marshaling and isn't a referenced type
+			if (!artifact.input?.types[type]) {
+				return [fieldName, value]
 			}
 
 			// we ran into an object type that should be referenced by the artifact

--- a/packages/houdini/runtime/scalars.ts
+++ b/packages/houdini/runtime/scalars.ts
@@ -3,7 +3,7 @@ import type { Config } from 'houdini-common'
 // locals
 import { MutationArtifact, QueryArtifact, SubscriptionArtifact } from './types'
 
-export function marshalInputs({
+export function marshalInputs<T>({
 	artifact,
 	config,
 	input,
@@ -13,10 +13,10 @@ export function marshalInputs({
 	config: Config
 	input: unknown
 	rootType: string
-}) {
+}): {} {
 	// if there are no inputs in the object, nothing to do
 	if (!artifact.input) {
-		return input
+		return input as {}
 	}
 
 	// the object containing the relevant fields
@@ -47,6 +47,4 @@ export function marshalInputs({
 			return [fieldName, marshalInputs({ artifact, config, input: value, rootType: type })]
 		})
 	)
-
-	return input
 }

--- a/packages/houdini/runtime/scalars.ts
+++ b/packages/houdini/runtime/scalars.ts
@@ -18,7 +18,11 @@ export function marshalInputs<T>({
 	config: Config
 	input: unknown
 	rootType?: string
-}): {} {
+}): {} | null | undefined {
+	if (input === null || typeof input === 'undefined') {
+		return input
+	}
+
 	// if there are no inputs in the object, nothing to do
 	if (!artifact.input) {
 		return input as {}
@@ -63,7 +67,11 @@ export function unmarshalSelection(
 	config: Config,
 	selection: SubscriptionSelection,
 	data: unknown
-): {} {
+): {} | null | undefined {
+	if (data === null || typeof data === 'undefined') {
+		return data
+	}
+
 	// if we are looking at a list
 	if (Array.isArray(data)) {
 		// unmarshal every entry in the list

--- a/packages/houdini/runtime/scalars.ts
+++ b/packages/houdini/runtime/scalars.ts
@@ -1,1 +1,17 @@
-export function foo() {}
+// externals
+import type { Config } from 'houdini-common'
+// locals
+import { MutationArtifact, QueryArtifact, SubscriptionArtifact } from './types'
+
+export function marshalInputs({
+	artifact,
+	config,
+	input,
+}: {
+	artifact: QueryArtifact | MutationArtifact | SubscriptionArtifact
+	config: Config
+	input: {}
+}) {
+	console.log(artifact.input)
+	return input
+}

--- a/packages/houdini/runtime/scalars.ts
+++ b/packages/houdini/runtime/scalars.ts
@@ -12,6 +12,6 @@ export function marshalInputs({
 	config: Config
 	input: {}
 }) {
-	console.log(artifact.input)
+	console.log(config, artifact.input)
 	return input
 }

--- a/packages/houdini/runtime/scalars.ts
+++ b/packages/houdini/runtime/scalars.ts
@@ -12,7 +12,7 @@ export function marshalInputs<T>({
 	artifact: QueryArtifact | MutationArtifact | SubscriptionArtifact
 	config: Config
 	input: unknown
-	rootType: string
+	rootType?: string
 }): {} {
 	// if there are no inputs in the object, nothing to do
 	if (!artifact.input) {

--- a/packages/houdini/runtime/subscription.ts
+++ b/packages/houdini/runtime/subscription.ts
@@ -5,7 +5,7 @@ import { onMount, onDestroy } from 'svelte'
 import { Operation, GraphQLTagResult, SubscriptionArtifact } from './types'
 import { getEnvironment } from './network'
 import cache from './cache'
-import { marshalInputs } from './scalars'
+import { marshalInputs, unmarshalSelection } from './scalars'
 
 // subscription holds open a live connection to the server. it returns a store
 // containing the requested data. Houdini will also update the cache with any
@@ -80,7 +80,9 @@ export default function subscription<_Subscription extends Operation<any, any>>(
 						cache.write(selection, data, marshaledVariables)
 
 						// update the local store
-						store.set(data)
+						store.set(
+							unmarshalSelection(document.config, document.artifact.selection, data)
+						)
 					}
 				},
 				error(data: _Subscription['result']) {},

--- a/packages/houdini/runtime/subscription.ts
+++ b/packages/houdini/runtime/subscription.ts
@@ -52,7 +52,7 @@ export default function subscription<_Subscription extends Operation<any, any>>(
 		input: variables || {},
 		config: config,
 		artifact: document.artifact,
-	})
+	}) as _Subscription['input']
 
 	// the websocket connection only exists on the client
 	onMount(() => {

--- a/packages/houdini/runtime/types.ts
+++ b/packages/houdini/runtime/types.ts
@@ -1,3 +1,5 @@
+import type { Config } from 'houdini-common'
+
 export type Fragment<_Result> = {
 	readonly shape?: _Result
 }
@@ -56,18 +58,21 @@ export type GraphQLTagResult =
 export type TaggedGraphqlFragment = {
 	kind: 'HoudiniFragment'
 	artifact: FragmentArtifact
+	config: Config
 }
 
 // the result of tagging an operation
 export type TaggedGraphqlMutation = {
 	kind: 'HoudiniMutation'
 	artifact: MutationArtifact
+	config: Config
 }
 
 // the result of tagging an operation
 export type TaggedGraphqlSubscription = {
 	kind: 'HoudiniSubscription'
 	artifact: SubscriptionArtifact
+	config: Config
 }
 
 // the result of tagging an operation
@@ -76,6 +81,7 @@ export type TaggedGraphqlQuery = {
 	initialValue: any
 	variables: { [key: string]: any }
 	artifact: QueryArtifact
+	config: Config
 }
 
 type Filter = { [key: string]: string | boolean | number }

--- a/packages/houdini/runtime/types.ts
+++ b/packages/houdini/runtime/types.ts
@@ -40,6 +40,10 @@ type BaseCompiledDocument = {
 	hash: string
 	selection: SubscriptionSelection
 	rootType: string
+	input?: {
+		fields: Record<string, string>
+		types: Record<string, Record<string, string>>
+	}
 }
 
 // the result of the template tag
@@ -137,11 +141,3 @@ export type SubscriptionSpec = {
 	parentID?: string
 	variables?: () => any
 }
-
-export type JSONValue =
-	| string
-	| number
-	| boolean
-	| null
-	| JSONValue[]
-	| { [key: string]: JSONValue }

--- a/packages/houdini/runtime/types.ts
+++ b/packages/houdini/runtime/types.ts
@@ -137,3 +137,11 @@ export type SubscriptionSpec = {
 	parentID?: string
 	variables?: () => any
 }
+
+export type JSONValue =
+	| string
+	| number
+	| boolean
+	| null
+	| JSONValue[]
+	| { [key: string]: JSONValue }

--- a/packages/houdini/tsconfig.json
+++ b/packages/houdini/tsconfig.json
@@ -4,7 +4,7 @@
 		"outDir": "build"
 	},
 	"include": ["cmd/**/*", "runtime/**/*"],
-	"exclude": ["node_modules", "**/*.test.ts"],
+	"exclude": ["node_modules", "**/*.test.ts", "*/build/**/*"],
 	"paths": {
 		"houdini-common": ["../houdini-common", "src"]
 	}


### PR DESCRIPTION
This PR adds support for custom scalars, defined by adding a `scalars` key to the `houdini.config.js`. Since this file is imported by the runtime and server code, the imports and logic must be able to run in both environments. This means that users that are relying on `process.env` and other server-only logic will need to use a replace plugin to make it work. This also means that the config file can no longer import `path`. I tried to find an alternative but this was the best compromise I could come up with. 


An example scalar definition: 

```javascript
// houdini.config.js

export default {
	// ...

	scalars: {
		// the name of the scalar we are configuring
		DateTime: {
			// the corresponding typescript type 
			type: 'Date',
			// turn the api's response into that type
			unmarshal(val) {
				return new Date(val)
			},
			// turn the value into something the API can use
			marshal(date) {
				return date.getTime()
			},
		},
	},
}
```

closes #56 