### PR TITLE
Separate generated docs

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -6,7 +6,7 @@
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",
 		"start": "svelte-kit start",
-		"generate": "rm -rf \"$houdini\" && houdini generate",
+		"generate": "rm -rf \"\\$houdini\" && houdini generate",
 		"api": "node api.cjs"
 	},
 	"devDependencies": {

--- a/example/package.json
+++ b/example/package.json
@@ -6,7 +6,7 @@
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",
 		"start": "svelte-kit start",
-		"generate": "houdini generate",
+		"generate": "rm -rf \"$houdini\" && houdini generate",
 		"api": "node api.cjs"
 	},
 	"devDependencies": {

--- a/packages/houdini/cmd/generate.ts
+++ b/packages/houdini/cmd/generate.ts
@@ -127,6 +127,7 @@ async function collectDocuments(config: Config): Promise<CollectedGraphQLDocumen
 									document: parsedDoc,
 									filename: filePath,
 									originalDocument: parsedDoc,
+									generated: false,
 								})
 							}
 						},

--- a/packages/houdini/cmd/generators/artifacts/artifacts.test.ts
+++ b/packages/houdini/cmd/generators/artifacts/artifacts.test.ts
@@ -16,8 +16,8 @@ const config = testConfig()
 
 // the documents to test
 const docs: CollectedGraphQLDocument[] = [
-	mockCollectedDoc('TestQuery', `query TestQuery { version }`),
-	mockCollectedDoc('TestFragment', `fragment TestFragment on User { firstName }`),
+	mockCollectedDoc(`query TestQuery { version }`),
+	mockCollectedDoc(`fragment TestFragment on User { firstName }`),
 ]
 
 test('generates an artifact for every document', async function () {
@@ -102,8 +102,8 @@ test('adds kind, name, and raw, response, and selection', async function () {
 test('selection includes fragments', async function () {
 	// the documents to test
 	const selectionDocs: CollectedGraphQLDocument[] = [
-		mockCollectedDoc('TestQuery', `query TestQuery { user { ...TestFragment } }`),
-		mockCollectedDoc('TestFragment', `fragment TestFragment on User { firstName }`),
+		mockCollectedDoc(`query TestQuery { user { ...TestFragment } }`),
+		mockCollectedDoc(`fragment TestFragment on User { firstName }`),
 	]
 
 	// execute the generator
@@ -196,8 +196,8 @@ test('selection includes fragments', async function () {
 test('internal directives are scrubbed', async function () {
 	// execute the generator
 	await runPipeline(config, [
-		mockCollectedDoc('Fragment', `fragment A on User { firstName }`),
-		mockCollectedDoc('TestQuery', `query TestQuery { user { ...A @prepend } }`),
+		mockCollectedDoc(`fragment A on User { firstName }`),
+		mockCollectedDoc(`query TestQuery { user { ...A @prepend } }`),
 	])
 
 	// load the contents of the file
@@ -255,8 +255,8 @@ test('internal directives are scrubbed', async function () {
 test('overlapping query and fragment selection', async function () {
 	// execute the generator
 	await runPipeline(config, [
-		mockCollectedDoc('Fragment', `fragment A on User { firstName }`),
-		mockCollectedDoc('TestQuery', `query TestQuery { user { firstName ...A @prepend } }`),
+		mockCollectedDoc(`fragment A on User { firstName }`),
+		mockCollectedDoc(`query TestQuery { user { firstName ...A @prepend } }`),
 	])
 
 	// load the contents of the file
@@ -315,11 +315,8 @@ test('overlapping query and fragment selection', async function () {
 test('overlapping query and fragment nested selection', async function () {
 	// execute the generator
 	await runPipeline(config, [
-		mockCollectedDoc('Fragment', `fragment A on User { friends { id } }`),
-		mockCollectedDoc(
-			'TestQuery',
-			`query TestQuery { user { friends { firstName } ...A @prepend } }`
-		),
+		mockCollectedDoc(`fragment A on User { friends { id } }`),
+		mockCollectedDoc(`query TestQuery { user { friends { firstName } ...A @prepend } }`),
 	])
 
 	// load the contents of the file
@@ -396,7 +393,6 @@ test('selections with interfaces', async function () {
 	const cfg = testConfig({ mode: 'kit' })
 	const mutationDocs = [
 		mockCollectedDoc(
-			'TestQuery',
 			`query Friends {
 					friends {
                         ... on Cat {
@@ -429,7 +425,7 @@ test('selections with interfaces', async function () {
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
 		export default {
-		    name: "TestQuery",
+		    name: "Friends",
 		    kind: "HoudiniQuery",
 
 		    raw: \`query Friends {
@@ -501,7 +497,6 @@ test('selections with unions', async function () {
 	const cfg = testConfig({ mode: 'kit' })
 	const mutationDocs = [
 		mockCollectedDoc(
-			'TestQuery',
 			`query Friends {
 					entities {
                         ... on Cat {
@@ -534,7 +529,7 @@ test('selections with unions', async function () {
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
 		export default {
-		    name: "TestQuery",
+		    name: "Friends",
 		    kind: "HoudiniQuery",
 
 		    raw: \`query Friends {
@@ -608,7 +603,6 @@ describe('mutation artifacts', function () {
 
 		const mutationDocs = [
 			mockCollectedDoc(
-				'Mutation B',
 				`mutation B {
 					addFriend {
 						friend {
@@ -618,7 +612,6 @@ describe('mutation artifacts', function () {
 				}`
 			),
 			mockCollectedDoc(
-				'TestQuery',
 				`query TestQuery {
 					users(stringValue: "foo") @list(name: "All_Users") {
 						firstName
@@ -643,7 +636,7 @@ describe('mutation artifacts', function () {
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
 		export default {
-		    name: "Mutation B",
+		    name: "B",
 		    kind: "HoudiniMutation",
 
 		    raw: \`mutation B {
@@ -690,7 +683,6 @@ describe('mutation artifacts', function () {
 	test('insert operation', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
-				'Mutation A',
 				`mutation A {
 					addFriend {
 						friend {
@@ -700,7 +692,6 @@ describe('mutation artifacts', function () {
 				}`
 			),
 			mockCollectedDoc(
-				'TestQuery',
 				`query TestQuery {
 					users(stringValue: "foo") @list(name: "All_Users") {
 						firstName
@@ -725,7 +716,7 @@ describe('mutation artifacts', function () {
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
 		module.exports = {
-		    name: "Mutation A",
+		    name: "A",
 		    kind: "HoudiniMutation",
 
 		    raw: \`mutation A {
@@ -783,7 +774,6 @@ describe('mutation artifacts', function () {
 	test('remove operation', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
-				'Mutation A',
 				`mutation A {
 					addFriend {
 						friend {
@@ -793,7 +783,6 @@ describe('mutation artifacts', function () {
 				}`
 			),
 			mockCollectedDoc(
-				'TestQuery',
 				`query TestQuery {
 					users(stringValue: "foo") @list(name: "All_Users") {
 						firstName
@@ -818,7 +807,7 @@ describe('mutation artifacts', function () {
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
 		module.exports = {
-		    name: "Mutation A",
+		    name: "A",
 		    kind: "HoudiniMutation",
 
 		    raw: \`mutation A {
@@ -869,7 +858,6 @@ describe('mutation artifacts', function () {
 	test('delete operation', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
-				'Mutation A',
 				`mutation A {
 					deleteUser(id: "1234") {
 						userID @User_delete
@@ -877,7 +865,6 @@ describe('mutation artifacts', function () {
 				}`
 			),
 			mockCollectedDoc(
-				'TestQuery',
 				`query TestQuery {
 					users(stringValue: "foo") @list(name: "All_Users") {
 						firstName
@@ -902,7 +889,7 @@ describe('mutation artifacts', function () {
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
 		module.exports = {
-		    name: "Mutation A",
+		    name: "A",
 		    kind: "HoudiniMutation",
 
 		    raw: \`mutation A {
@@ -939,7 +926,6 @@ describe('mutation artifacts', function () {
 	test('delete operation with condition', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
-				'Mutation A',
 				`mutation A {
 					deleteUser(id: "1234") {
 						userID @User_delete @when(argument: "stringValue", value: "foo")
@@ -947,7 +933,6 @@ describe('mutation artifacts', function () {
 				}`
 			),
 			mockCollectedDoc(
-				'TestQuery',
 				`query TestQuery {
 					users(stringValue: "foo") @list(name: "All_Users") {
 						firstName
@@ -972,7 +957,7 @@ describe('mutation artifacts', function () {
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
 		module.exports = {
-		    name: "Mutation A",
+		    name: "A",
 		    kind: "HoudiniMutation",
 
 		    raw: \`mutation A {
@@ -1015,7 +1000,6 @@ describe('mutation artifacts', function () {
 	test('parentID - prepend', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
-				'Mutation A',
 				`mutation A {
 					addFriend {
 						friend {
@@ -1025,7 +1009,6 @@ describe('mutation artifacts', function () {
 				}`
 			),
 			mockCollectedDoc(
-				'TestQuery',
 				`query TestQuery {
 					users(stringValue: "foo") @list(name: "All_Users") {
 						firstName
@@ -1050,7 +1033,7 @@ describe('mutation artifacts', function () {
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
 		module.exports = {
-		    name: "Mutation A",
+		    name: "A",
 		    kind: "HoudiniMutation",
 
 		    raw: \`mutation A {
@@ -1113,7 +1096,6 @@ describe('mutation artifacts', function () {
 	test('parentID - append', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
-				'Mutation A',
 				`mutation A {
 					addFriend {
 						friend {
@@ -1123,7 +1105,6 @@ describe('mutation artifacts', function () {
 				}`
 			),
 			mockCollectedDoc(
-				'TestQuery',
 				`query TestQuery {
 					users(stringValue: "foo") @list(name: "All_Users") {
 						firstName
@@ -1148,7 +1129,7 @@ describe('mutation artifacts', function () {
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
 		module.exports = {
-		    name: "Mutation A",
+		    name: "A",
 		    kind: "HoudiniMutation",
 
 		    raw: \`mutation A {
@@ -1211,7 +1192,6 @@ describe('mutation artifacts', function () {
 	test('parentID - parentID directive', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
-				'Mutation A',
 				`mutation A {
 					addFriend {
 						friend {
@@ -1221,7 +1201,6 @@ describe('mutation artifacts', function () {
 				}`
 			),
 			mockCollectedDoc(
-				'TestQuery',
 				`query TestQuery {
 					users(stringValue: "foo") @list(name: "All_Users") {
 						firstName
@@ -1246,7 +1225,7 @@ describe('mutation artifacts', function () {
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
 		module.exports = {
-		    name: "Mutation A",
+		    name: "A",
 		    kind: "HoudiniMutation",
 
 		    raw: \`mutation A {
@@ -1309,7 +1288,6 @@ describe('mutation artifacts', function () {
 	test('must - prepend', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
-				'Mutation A',
 				`mutation A {
 					addFriend {
 						friend {
@@ -1319,7 +1297,6 @@ describe('mutation artifacts', function () {
 				}`
 			),
 			mockCollectedDoc(
-				'TestQuery',
 				`query TestQuery {
 					users(stringValue: "foo") @list(name: "All_Users") {
 						firstName
@@ -1344,7 +1321,7 @@ describe('mutation artifacts', function () {
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
 		module.exports = {
-		    name: "Mutation A",
+		    name: "A",
 		    kind: "HoudiniMutation",
 
 		    raw: \`mutation A {
@@ -1408,7 +1385,6 @@ describe('mutation artifacts', function () {
 	test('must - append', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
-				'Mutation A',
 				`mutation A {
 					addFriend {
 						friend {
@@ -1418,7 +1394,6 @@ describe('mutation artifacts', function () {
 				}`
 			),
 			mockCollectedDoc(
-				'TestQuery',
 				`query TestQuery {
 					users(stringValue: "foo") @list(name: "All_Users") {
 						firstName
@@ -1443,7 +1418,7 @@ describe('mutation artifacts', function () {
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
 		module.exports = {
-		    name: "Mutation A",
+		    name: "A",
 		    kind: "HoudiniMutation",
 
 		    raw: \`mutation A {
@@ -1507,7 +1482,6 @@ describe('mutation artifacts', function () {
 	test('must - directive', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
-				'Mutation A',
 				`mutation A {
 					addFriend {
 						friend {
@@ -1517,7 +1491,6 @@ describe('mutation artifacts', function () {
 				}`
 			),
 			mockCollectedDoc(
-				'TestQuery',
 				`query TestQuery {
 					users(stringValue: "foo") @list(name: "All_Users") {
 						firstName
@@ -1542,7 +1515,7 @@ describe('mutation artifacts', function () {
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
 		module.exports = {
-		    name: "Mutation A",
+		    name: "A",
 		    kind: "HoudiniMutation",
 
 		    raw: \`mutation A {
@@ -1606,7 +1579,6 @@ describe('mutation artifacts', function () {
 	test('must_not - prepend', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
-				'Mutation A',
 				`mutation A {
 					addFriend {
 						friend {
@@ -1616,7 +1588,6 @@ describe('mutation artifacts', function () {
 				}`
 			),
 			mockCollectedDoc(
-				'TestQuery',
 				`query TestQuery {
 					users(stringValue: "foo") @list(name: "All_Users") {
 						firstName
@@ -1641,7 +1612,7 @@ describe('mutation artifacts', function () {
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
 		module.exports = {
-		    name: "Mutation A",
+		    name: "A",
 		    kind: "HoudiniMutation",
 
 		    raw: \`mutation A {
@@ -1705,7 +1676,6 @@ describe('mutation artifacts', function () {
 	test('must_not - append', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
-				'Mutation A',
 				`mutation A {
 					addFriend {
 						friend {
@@ -1715,7 +1685,6 @@ describe('mutation artifacts', function () {
 				}`
 			),
 			mockCollectedDoc(
-				'TestQuery',
 				`query TestQuery {
 					users(stringValue: "foo") @list(name: "All_Users") {
 						firstName
@@ -1740,7 +1709,7 @@ describe('mutation artifacts', function () {
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
 		module.exports = {
-		    name: "Mutation A",
+		    name: "A",
 		    kind: "HoudiniMutation",
 
 		    raw: \`mutation A {
@@ -1804,7 +1773,6 @@ describe('mutation artifacts', function () {
 	test('list filters', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
-				'Mutation A',
 				`mutation A {
 					addFriend {
 						friend {
@@ -1814,7 +1782,6 @@ describe('mutation artifacts', function () {
 				}`
 			),
 			mockCollectedDoc(
-				'TestQuery',
 				`query TestQuery($value: String!) {
 					users(
 						stringValue: $value,
@@ -1914,7 +1881,6 @@ describe('mutation artifacts', function () {
 	test('must_not - directive', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
-				'Mutation A',
 				`mutation A {
 					addFriend {
 						friend {
@@ -1924,7 +1890,6 @@ describe('mutation artifacts', function () {
 				}`
 			),
 			mockCollectedDoc(
-				'TestQuery',
 				`query TestQuery {
 					users(stringValue: "foo", boolValue:true) @list(name: "All_Users") {
 						firstName
@@ -1949,7 +1914,7 @@ describe('mutation artifacts', function () {
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
 		module.exports = {
-		    name: "Mutation A",
+		    name: "A",
 		    kind: "HoudiniMutation",
 
 		    raw: \`mutation A {
@@ -2013,7 +1978,6 @@ describe('mutation artifacts', function () {
 	test('tracks list name', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
-				'Mutation A',
 				`mutation A {
 					addFriend {
 						friend {
@@ -2023,7 +1987,6 @@ describe('mutation artifacts', function () {
 				}`
 			),
 			mockCollectedDoc(
-				'TestQuery',
 				`query TestQuery {
 					users(stringValue: "foo") @list(name: "All_Users") {
 						firstName
@@ -2095,7 +2058,6 @@ describe('mutation artifacts', function () {
 	test('field args', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
-				'TestQuery',
 				`query TestQuery($value: String!) {
 					users(
 						stringValue: $value,
@@ -2197,7 +2159,6 @@ describe('mutation artifacts', function () {
 
 		const mutationDocs = [
 			mockCollectedDoc(
-				'TestQuery',
 				`query TestQuery($value: String!) {
 					users(
 						stringValue: $value,
@@ -2322,9 +2283,7 @@ test('custom scalar shows up in artifact', async function () {
 	})
 
 	// execute the generator
-	await runPipeline(localConfig, [
-		mockCollectedDoc('TestQuery', `query TestQuery { allItems { createdAt } }`),
-	])
+	await runPipeline(localConfig, [mockCollectedDoc(`query TestQuery { allItems { createdAt } }`)])
 
 	// load the contents of the file
 	const queryContents = await fs.readFile(
@@ -2405,7 +2364,6 @@ test('operation inputs', async function () {
 	// execute the generator
 	await runPipeline(localConfig, [
 		mockCollectedDoc(
-			'TestQuery',
 			`
 			query TestQuery(
 				$id: ID,
@@ -2499,7 +2457,6 @@ describe('subscription artifacts', function () {
 	test('happy path', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
-				'Subscription B',
 				`subscription B {
 					newUser {
 						user {
@@ -2526,7 +2483,7 @@ describe('subscription artifacts', function () {
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
 		module.exports = {
-		    name: "Subscription B",
+		    name: "B",
 		    kind: "HoudiniSubscription",
 
 		    raw: \`subscription B {

--- a/packages/houdini/cmd/generators/artifacts/index.ts
+++ b/packages/houdini/cmd/generators/artifacts/index.ts
@@ -233,7 +233,6 @@ export default async function artifactGenerator(config: Config, docs: CollectedG
 
 				// write the result to the artifact path we're configured to write to
 				await writeFile(config.artifactPath(document), recast.print(file).code)
-				console.log(config.artifactPath(document), docKind)
 				// log the file location to confirm
 				if (!config.quiet) {
 					console.log(name)

--- a/packages/houdini/cmd/generators/artifacts/indexFile.test.ts
+++ b/packages/houdini/cmd/generators/artifacts/indexFile.test.ts
@@ -16,8 +16,8 @@ const config = testConfig()
 
 // the documents to test
 const docs: CollectedGraphQLDocument[] = [
-	mockCollectedDoc('TestQuery', `query TestQuery { version }`),
-	mockCollectedDoc('TestFragment', `fragment TestFragment on User { firstName }`),
+	mockCollectedDoc(`query TestQuery { version }`),
+	mockCollectedDoc(`fragment TestFragment on User { firstName }`),
 ]
 
 test('index file - kit', async function () {

--- a/packages/houdini/cmd/generators/artifacts/indexFile.ts
+++ b/packages/houdini/cmd/generators/artifacts/indexFile.ts
@@ -9,15 +9,17 @@ import { cjsIndexFilePreamble, exportDefaultFrom, writeFile } from '../../utils'
 const AST = recast.types.builders
 
 export default async function writeIndexFile(config: Config, docs: CollectedGraphQLDocument[]) {
+	const nonGeneratedDocs = docs.filter((doc) => !doc.generated)
+
 	// we want to export every artifact from the index file.
 	let body =
 		config.module === 'esm'
-			? docs.reduce(
+			? nonGeneratedDocs.reduce(
 					(content, doc) =>
 						content + `\n export { default as ${doc.name}} from './${doc.name}'`,
 					''
 			  )
-			: docs.reduce(
+			: nonGeneratedDocs.reduce(
 					(content, doc) => content + `\n${exportDefaultFrom(`./${doc.name}`, doc.name)}`,
 					cjsIndexFilePreamble
 			  )

--- a/packages/houdini/cmd/generators/runtime/indexFile.test.ts
+++ b/packages/houdini/cmd/generators/runtime/indexFile.test.ts
@@ -13,8 +13,8 @@ import { mockCollectedDoc } from '../../testUtils'
 
 // the documents to test
 const docs: CollectedGraphQLDocument[] = [
-	mockCollectedDoc('TestQuery', `query TestQuery { version }`),
-	mockCollectedDoc('TestFragment', `fragment TestFragment on User { firstName }`),
+	mockCollectedDoc(`query TestQuery { version }`),
+	mockCollectedDoc(`fragment TestFragment on User { firstName }`),
 ]
 
 test('runtime index file - sapper', async function () {

--- a/packages/houdini/cmd/generators/typescript/index.ts
+++ b/packages/houdini/cmd/generators/typescript/index.ts
@@ -27,7 +27,11 @@ export default async function typescriptGenerator(
 		// the generated types depend solely on user-provided information
 		// so we need to use the original document that we haven't mutated
 		// as part of the compiler
-		docs.map(async ({ originalDocument }) => {
+		docs.map(async ({ originalDocument, generated }) => {
+			if (generated) {
+				return
+			}
+
 			// the place to put the artifact's type definition
 			const typeDefPath = config.artifactTypePath(originalDocument)
 

--- a/packages/houdini/cmd/generators/typescript/typescript.test.ts
+++ b/packages/houdini/cmd/generators/typescript/typescript.test.ts
@@ -94,7 +94,6 @@ describe('typescript', function () {
 	test('fragment types', async function () {
 		// the document to test
 		const doc = mockCollectedDoc(
-			'TestFragment',
 			`fragment TestFragment on User { firstName nickname enumValue }`
 		)
 
@@ -133,7 +132,7 @@ describe('typescript', function () {
 		const fragment = `fragment TestFragment on User { firstName parent { firstName } }`
 
 		// the document to test
-		const doc = mockCollectedDoc('TestFragment', fragment)
+		const doc = mockCollectedDoc(fragment)
 
 		// execute the generator
 		await runPipeline(config, [doc])
@@ -166,7 +165,6 @@ describe('typescript', function () {
 	test('scalars', async function () {
 		// the document to test
 		const doc = mockCollectedDoc(
-			'TestFragment',
 			`fragment TestFragment on User { firstName admin age id weight }`
 		)
 
@@ -202,7 +200,6 @@ describe('typescript', function () {
 	test('list types', async function () {
 		// the document to test
 		const doc = mockCollectedDoc(
-			'TestFragment',
 			`fragment TestFragment on User { firstName friends { firstName } }`
 		)
 
@@ -236,7 +233,7 @@ describe('typescript', function () {
 
 	test('query with no input', async function () {
 		// the document to test
-		const doc = mockCollectedDoc('TestFragment', `query Query { user { firstName } }`)
+		const doc = mockCollectedDoc(`query Query { user { firstName } }`)
 
 		// execute the generator
 		await runPipeline(config, [doc])
@@ -265,20 +262,13 @@ describe('typescript', function () {
 
 	test('query with root list', async function () {
 		// the document with the query
-		const query = `
+		const queryDoc = mockCollectedDoc(`
 			query Query {
 				users {
 					firstName,
 				}
 			}
-		`
-		const queryDoc = {
-			name: 'Query',
-			document: graphql.parse(query),
-			originalDocument: graphql.parse(query),
-			filename: 'fragment.ts',
-			printed: query,
-		}
+		`)
 		// execute the generator
 		await runPipeline(config, [queryDoc])
 
@@ -307,7 +297,6 @@ describe('typescript', function () {
 	test('query with input', async function () {
 		// the document to test
 		const doc = mockCollectedDoc(
-			'TestFragment',
 			`query Query($id: ID!, $enum: MyEnum) { user(id: $id, enumArg: $enum ) { firstName } }`
 		)
 
@@ -348,7 +337,6 @@ describe('typescript', function () {
 	test('mutation with input list', async function () {
 		// the document to test
 		const doc = mockCollectedDoc(
-			'TestFragment',
 			`mutation Mutation(
 				$filter: UserFilter, 
 				$filterList: [UserFilter!]!, 
@@ -429,7 +417,6 @@ describe('typescript', function () {
 	test('nested input objects', async function () {
 		// the document to test
 		const doc = mockCollectedDoc(
-			'TestFragment',
 			`query Query($filter: UserFilter!) { user(filter: $filter) { firstName } }`
 		)
 
@@ -485,7 +472,6 @@ describe('typescript', function () {
 	test('generates index file', async function () {
 		// the document to test
 		const doc = mockCollectedDoc(
-			'Query',
 			`query Query($filter: UserFilter!) { user(filter: $filter) { firstName } }`
 		)
 
@@ -507,10 +493,10 @@ describe('typescript', function () {
 
 	test('fragment spreads', async function () {
 		// the document with the fragment
-		const fragment = mockCollectedDoc('Foo', `fragment Foo on User { firstName }`)
+		const fragment = mockCollectedDoc(`fragment Foo on User { firstName }`)
 
 		// the document to test
-		const query = mockCollectedDoc('Query', `query Query { user { ...Foo } }`)
+		const query = mockCollectedDoc(`query Query { user { ...Foo } }`)
 
 		// execute the generator
 		await runPipeline(config, [query, fragment])
@@ -542,7 +528,6 @@ describe('typescript', function () {
 	test('interfaces', async function () {
 		// the document to test
 		const query = mockCollectedDoc(
-			'Query',
 			`
 			query Query { 
 				nodes { 
@@ -589,7 +574,6 @@ describe('typescript', function () {
 	test('unions', async function () {
 		// the document to test
 		const query = mockCollectedDoc(
-			'Query',
 			`
 			query Query { 
 				entities { 
@@ -636,7 +620,6 @@ describe('typescript', function () {
 	test('discriminated interface', async function () {
 		// the document to test
 		const query = mockCollectedDoc(
-			'Query',
 			`
 			query Query { 
 				nodes { 
@@ -686,7 +669,6 @@ describe('typescript', function () {
 	test('intersecting interface', async function () {
 		// the document to test
 		const query = mockCollectedDoc(
-			'Query',
 			`
 			query Query { 
 				entities { 
@@ -764,7 +746,7 @@ describe('typescript', function () {
 		})
 
 		// the document to test
-		const query = mockCollectedDoc('Query', `query Query { allItems { createdAt } }`)
+		const query = mockCollectedDoc(`query Query { allItems { createdAt } }`)
 
 		// execute the generator
 		await runPipeline(localConfig, [query])
@@ -821,7 +803,6 @@ describe('typescript', function () {
 
 		// the document to test
 		const query = mockCollectedDoc(
-			'Query',
 			`query Query($date: DateTime!) { allItems(createdAt: $date) { createdAt } }`
 		)
 

--- a/packages/houdini/cmd/testUtils.ts
+++ b/packages/houdini/cmd/testUtils.ts
@@ -63,5 +63,6 @@ export function mockCollectedDoc(name: string, query: string) {
 		originalDocument: graphql.parse(query),
 		filename: `${name}.ts`,
 		printed: query,
+		generated: false,
 	}
 }

--- a/packages/houdini/cmd/testUtils.ts
+++ b/packages/houdini/cmd/testUtils.ts
@@ -15,17 +15,7 @@ export function pipelineTest(
 ) {
 	test(title, async function () {
 		// the first thing to do is to create the list of collected documents
-		const docs: CollectedGraphQLDocument[] = documents.map((documentBody) => {
-			// parse the graphql document
-			const document = graphql.parse(documentBody)
-
-			// assume we didn't do anything crazy and there's only a single document per case
-			const definition = document.definitions[0] as
-				| graphql.FragmentDefinitionNode
-				| graphql.OperationDefinitionNode
-
-			return mockCollectedDoc(definition.name?.value || 'NO_NAME', documentBody)
-		})
+		const docs: CollectedGraphQLDocument[] = documents.map(mockCollectedDoc)
 
 		// we need to trap if we didn't fail
 		let error: HoudiniError[] = []
@@ -56,11 +46,17 @@ export function pipelineTest(
 	})
 }
 
-export function mockCollectedDoc(name: string, query: string) {
+export function mockCollectedDoc(query: string) {
+	const parsed = graphql.parse(query)
+
+	// look at the first definition in the pile for the name
+	// @ts-ignore
+	const name = parsed.definitions[0].name.value
+
 	return {
 		name,
-		document: graphql.parse(query),
-		originalDocument: graphql.parse(query),
+		document: parsed,
+		originalDocument: parsed,
 		filename: `${name}.ts`,
 		printed: query,
 		generated: false,

--- a/packages/houdini/cmd/transforms/addID.test.ts
+++ b/packages/houdini/cmd/transforms/addID.test.ts
@@ -9,7 +9,6 @@ import { mockCollectedDoc } from '../testUtils'
 test('adds ids to selection sets of objects with them', async function () {
 	const docs = [
 		mockCollectedDoc(
-			'Friends',
 			`
 				query Friends {
                     user { 
@@ -38,7 +37,6 @@ test('adds ids to selection sets of objects with them', async function () {
 test("doesn't add id if there isn't one", async function () {
 	const docs = [
 		mockCollectedDoc(
-			'Friends',
 			`
 				query Friends {
                     ghost { 

--- a/packages/houdini/cmd/transforms/fragmentVariables.test.ts
+++ b/packages/houdini/cmd/transforms/fragmentVariables.test.ts
@@ -13,7 +13,6 @@ import { mockCollectedDoc } from '../testUtils'
 test('pass argument values to generated fragments', async function () {
 	const docs = [
 		mockCollectedDoc(
-			'TestQuery',
 			`
 				query AllUsers {
                     ...QueryFragment @with(name: "Hello")
@@ -21,7 +20,6 @@ test('pass argument values to generated fragments', async function () {
 			`
 		),
 		mockCollectedDoc(
-			'QueryFragment',
 			`
 				fragment QueryFragment on Query 
                 @arguments(name: {type: "String"} ) {
@@ -49,7 +47,7 @@ test('pass argument values to generated fragments', async function () {
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
 		module.exports = {
-		    name: "TestQuery",
+		    name: "AllUsers",
 		    kind: "HoudiniQuery",
 
 		    raw: \`query AllUsers {
@@ -85,7 +83,6 @@ test('pass argument values to generated fragments', async function () {
 test("fragment arguments with default values don't rename the fragment", async function () {
 	const docs = [
 		mockCollectedDoc(
-			'TestQuery',
 			`
 				query AllUsers {
                     ...QueryFragment
@@ -93,7 +90,6 @@ test("fragment arguments with default values don't rename the fragment", async f
 			`
 		),
 		mockCollectedDoc(
-			'QueryFragment',
 			`
 				fragment QueryFragment on Query 
                 @arguments(name: {type: "String", default: "Hello"}) {
@@ -121,7 +117,7 @@ test("fragment arguments with default values don't rename the fragment", async f
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
 		module.exports = {
-		    name: "TestQuery",
+		    name: "AllUsers",
 		    kind: "HoudiniQuery",
 
 		    raw: \`query AllUsers {
@@ -157,7 +153,6 @@ test("fragment arguments with default values don't rename the fragment", async f
 test('thread query variables to inner fragments', async function () {
 	const docs = [
 		mockCollectedDoc(
-			'TestQuery',
 			`
 				query AllUsers($name: String!) {
                     ...QueryFragment @with(name: $name)
@@ -165,7 +160,6 @@ test('thread query variables to inner fragments', async function () {
 			`
 		),
 		mockCollectedDoc(
-			'QueryFragment',
 			`
 				fragment QueryFragment on Query 
                 @arguments(name: {type: "String", default: "Hello"}) {
@@ -174,7 +168,6 @@ test('thread query variables to inner fragments', async function () {
 			`
 		),
 		mockCollectedDoc(
-			'InnerFragment',
 			`
 				fragment InnerFragment on Query 
                 @arguments(name: {type: "String", default: "Hello"}) {
@@ -202,7 +195,7 @@ test('thread query variables to inner fragments', async function () {
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
 		module.exports = {
-		    name: "TestQuery",
+		    name: "AllUsers",
 		    kind: "HoudiniQuery",
 
 		    raw: \`query AllUsers($name: String!) {
@@ -250,7 +243,6 @@ test('thread query variables to inner fragments', async function () {
 test('inner fragment with intermediate default value', async function () {
 	const docs = [
 		mockCollectedDoc(
-			'TestQuery',
 			`
 				query AllUsers {
                     ...QueryFragment
@@ -258,7 +250,6 @@ test('inner fragment with intermediate default value', async function () {
 			`
 		),
 		mockCollectedDoc(
-			'QueryFragment',
 			`
 				fragment QueryFragment on Query 
                 @arguments(name: {type: "String", default: "Hello"}) {
@@ -267,7 +258,6 @@ test('inner fragment with intermediate default value', async function () {
 			`
 		),
 		mockCollectedDoc(
-			'InnerFragment',
 			`
 				fragment InnerFragment on Query 
                 @arguments(name: {type: "String", default: "Goodbye"}, age: {type: "Int", default: 2}) {
@@ -295,7 +285,7 @@ test('inner fragment with intermediate default value', async function () {
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
 		module.exports = {
-		    name: "TestQuery",
+		    name: "AllUsers",
 		    kind: "HoudiniQuery",
 
 		    raw: \`query AllUsers {
@@ -335,7 +325,6 @@ test('inner fragment with intermediate default value', async function () {
 test("default values don't overwrite unless explicitly passed", async function () {
 	const docs = [
 		mockCollectedDoc(
-			'TestQuery',
 			`
 				query AllUsers {
                     ...QueryFragment
@@ -343,7 +332,6 @@ test("default values don't overwrite unless explicitly passed", async function (
 			`
 		),
 		mockCollectedDoc(
-			'QueryFragment',
 			`
 				fragment QueryFragment on Query 
                 @arguments(name: {type: "String", default: "Hello"}) {
@@ -352,7 +340,6 @@ test("default values don't overwrite unless explicitly passed", async function (
 			`
 		),
 		mockCollectedDoc(
-			'InnerFragment',
 			`
 				fragment InnerFragment on Query 
                 @arguments(name: {type: "String", default: "Goodbye"}) {
@@ -380,7 +367,7 @@ test("default values don't overwrite unless explicitly passed", async function (
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
 		module.exports = {
-		    name: "TestQuery",
+		    name: "AllUsers",
 		    kind: "HoudiniQuery",
 
 		    raw: \`query AllUsers {
@@ -420,7 +407,6 @@ test("default values don't overwrite unless explicitly passed", async function (
 test('default arguments', async function () {
 	const docs = [
 		mockCollectedDoc(
-			'TestQuery',
 			`
 				query AllUsers {
                     ...QueryFragment
@@ -428,7 +414,6 @@ test('default arguments', async function () {
 			`
 		),
 		mockCollectedDoc(
-			'QueryFragment',
 			`
 				fragment QueryFragment on Query 
                 @arguments(name: {type: "String", default: "Hello"}, cool: {type: "Boolean", default: true}) {
@@ -456,7 +441,7 @@ test('default arguments', async function () {
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
 		module.exports = {
-		    name: "TestQuery",
+		    name: "AllUsers",
 		    kind: "HoudiniQuery",
 
 		    raw: \`query AllUsers {
@@ -492,7 +477,6 @@ test('default arguments', async function () {
 test('multiple with directives - no overlap', async function () {
 	const docs = [
 		mockCollectedDoc(
-			'TestQuery',
 			`
 				query AllUsers {
                     ...QueryFragment @with(name: "Goodbye") @with(cool: false)
@@ -500,7 +484,6 @@ test('multiple with directives - no overlap', async function () {
 			`
 		),
 		mockCollectedDoc(
-			'QueryFragment',
 			`
 				fragment QueryFragment on Query 
                 @arguments(name: {type: "String", default: "Hello"}, cool: {type: "Boolean", default: true}) {
@@ -528,7 +511,7 @@ test('multiple with directives - no overlap', async function () {
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
 		module.exports = {
-		    name: "TestQuery",
+		    name: "AllUsers",
 		    kind: "HoudiniQuery",
 
 		    raw: \`query AllUsers {

--- a/packages/houdini/cmd/transforms/fragmentVariables.ts
+++ b/packages/houdini/cmd/transforms/fragmentVariables.ts
@@ -69,13 +69,18 @@ export default async function fragmentVariables(
 	// once we've handled every fragment in every document we need to add any
 	// new fragment definitions to the list of collected docs so they can be picked up
 	if (documents.length > 0) {
-		documents[0].document = {
-			...documents[0].document,
-			definitions: [
-				...documents[0].document.definitions,
-				...Object.values(generatedFragments),
-			],
+		const doc: graphql.DocumentNode = {
+			kind: 'Document',
+			definitions: Object.values(generatedFragments),
 		}
+
+		documents.push({
+			name: 'generated::fragmentVariables',
+			document: doc,
+			originalDocument: doc,
+			generated: true,
+			filename: '__generated__',
+		})
 	}
 }
 

--- a/packages/houdini/cmd/transforms/lists.test.ts
+++ b/packages/houdini/cmd/transforms/lists.test.ts
@@ -9,7 +9,6 @@ import { mockCollectedDoc } from '../testUtils'
 test('insert fragments on query selection set', async function () {
 	const docs = [
 		mockCollectedDoc(
-			'UpdateUser',
 			`
 				mutation UpdateUser {
 					updateUser {
@@ -19,7 +18,6 @@ test('insert fragments on query selection set', async function () {
 			`
 		),
 		mockCollectedDoc(
-			'TestQuery',
 			`
 				query AllUsers {
 					user {
@@ -56,7 +54,6 @@ test('insert fragments on query selection set', async function () {
 test('delete fragments on query selection set', async function () {
 	const docs = [
 		mockCollectedDoc(
-			'UpdateUser',
 			`
 				mutation UpdateUser {
 					updateUser {
@@ -66,7 +63,6 @@ test('delete fragments on query selection set', async function () {
 			`
 		),
 		mockCollectedDoc(
-			'TestQuery',
 			`
 				query AllUsers {
 					user {
@@ -102,7 +98,6 @@ test('delete fragments on query selection set', async function () {
 test('list fragments on fragment selection set', async function () {
 	const docs = [
 		mockCollectedDoc(
-			'UpdateUser',
 			`
 				mutation UpdateUser {
 					updateUser {
@@ -112,7 +107,6 @@ test('list fragments on fragment selection set', async function () {
 			`
 		),
 		mockCollectedDoc(
-			'TestQuery',
 			`
 				fragment AllUsers  on User{
 					friends @list(name:"User_Friends") {
@@ -147,7 +141,6 @@ test('list fragments on fragment selection set', async function () {
 test('delete node', async function () {
 	const docs = [
 		mockCollectedDoc(
-			'DeleteUser',
 			`
 				mutation DeleteUser {
 					deleteUser(id: "1234") {
@@ -157,7 +150,6 @@ test('delete node', async function () {
 			`
 		),
 		mockCollectedDoc(
-			'TestQuery',
 			`
 				fragment AllUsers  on User{
 					friends @list(name:"User_Friends") {
@@ -176,7 +168,6 @@ test('delete node', async function () {
 test('list fragments must be unique', async function () {
 	const docs = [
 		mockCollectedDoc(
-			'TestQuery',
 			`
 				query AllUsers {
 					user {
@@ -201,7 +192,6 @@ test('list fragments must be unique', async function () {
 test('includes `id` in list fragment', async function () {
 	const docs = [
 		mockCollectedDoc(
-			'UpdateUser',
 			`
 			mutation UpdateUser {
 				updateUser {
@@ -211,7 +201,6 @@ test('includes `id` in list fragment', async function () {
 		`
 		),
 		mockCollectedDoc(
-			'TestQuery',
 			`
 			fragment AllUsers  on User{
 				friends @list(name:"User_Friends") {
@@ -246,7 +235,6 @@ test('includes `id` in list fragment', async function () {
 test('cannot use list directive if id is not a valid field', async function () {
 	const docs = [
 		mockCollectedDoc(
-			'TestQuery',
 			`
 			query AllGhosts {
 				ghost {

--- a/packages/houdini/cmd/transforms/lists.test.ts
+++ b/packages/houdini/cmd/transforms/lists.test.ts
@@ -189,6 +189,29 @@ test('list fragments must be unique', async function () {
 	await expect(runPipeline(testConfig(), docs)).rejects.toBeTruthy()
 })
 
+test("fragment with list doesn't clutter its definition", async function () {
+	const docs = [
+		mockCollectedDoc(`fragment Friends on User  { 
+			friends @list(name:"Friends") {  
+				id
+			}
+		}`),
+	]
+
+	// run the pipeline
+	const config = testConfig()
+	await runPipeline(config, docs)
+
+	expect(docs[0].document).toMatchInlineSnapshot(`
+		fragment Friends on User {
+		  friends @list(name: "Friends") {
+		    id
+		  }
+		}
+
+	`)
+})
+
 test('includes `id` in list fragment', async function () {
 	const docs = [
 		mockCollectedDoc(

--- a/packages/houdini/cmd/transforms/typename.test.ts
+++ b/packages/houdini/cmd/transforms/typename.test.ts
@@ -9,7 +9,6 @@ import { mockCollectedDoc } from '../testUtils'
 test('adds __typename on interface selection sets under query', async function () {
 	const docs = [
 		mockCollectedDoc(
-			'Friends',
 			`
 				query Friends {
 					friends {
@@ -48,7 +47,6 @@ test('adds __typename on interface selection sets under query', async function (
 test('adds __typename on interface selection sets under an object', async function () {
 	const docs = [
 		mockCollectedDoc(
-			'Friends',
 			`
 				query Friends {
                     users(stringValue: "hello") { 
@@ -94,7 +92,6 @@ test('adds __typename on interface selection sets under an object', async functi
 test('adds __typename on unions', async function () {
 	const docs = [
 		mockCollectedDoc(
-			'Friends',
 			`
 				query Friends {
 					entities {

--- a/packages/houdini/cmd/types.ts
+++ b/packages/houdini/cmd/types.ts
@@ -7,6 +7,7 @@ export type CollectedGraphQLDocument = {
 	name: string
 	document: graphql.DocumentNode
 	originalDocument: graphql.DocumentNode
+	generated: boolean
 }
 
 // an error pertaining to a specific graphql document

--- a/packages/houdini/cmd/validators/noIDAlias.test.ts
+++ b/packages/houdini/cmd/validators/noIDAlias.test.ts
@@ -1,10 +1,9 @@
 // external imports
 import * as graphql from 'graphql'
-import { HoudiniError } from 'houdini-common'
 // locals
 import { pipelineTest } from '../testUtils'
 import '../../../../jest.setup'
-import { CollectedGraphQLDocument } from '../types'
+import { CollectedGraphQLDocument, HoudiniError } from '../types'
 
 const table: Row[] = [
 	{


### PR DESCRIPTION
This PR changes the approach when generating documents. Instead of adding additional definitions to the source document (which can confuse the generators), they are now added at the end of the pile with a `generated` flag that prevents the generators from processing them. Along the way, I also improve the document mocking utility to not require explicitly passing the document name.

fixes #133 