### PR TITLE
Persisted Queries #93

### DIFF
--- a/example/queryMap.json
+++ b/example/queryMap.json
@@ -1,0 +1,9 @@
+{
+	"e1bd3faf8b80f8206bcbbc236c4943a9": "mutation CompleteItem($id: ID!) {\n  checkItem(item: $id) {\n    item {\n      id\n      completed\n      ...Filtered_Items_remove\n    }\n  }\n}\n\nfragment Filtered_Items_remove on TodoItem {\n  id\n}\n",
+	"71fa4426fa8ba60f86d6fb0a2908c63c": "mutation UncompleteItem($id: ID!) {\n  uncheckItem(item: $id) {\n    item {\n      id\n      completed\n      ...Filtered_Items_remove\n    }\n  }\n}\n\nfragment Filtered_Items_remove on TodoItem {\n  id\n}\n",
+	"fc356a484115ab1638f9a51aae58d6ab": "mutation DeleteItem($id: ID!) {\n  deleteItem(item: $id) {\n    itemID\n  }\n}\n",
+	"2c0c4ce8b2a4ae98552ce72e6d677385": "subscription ItemUpdate($id: ID!) {\n  itemUpdate(id: $id) {\n    item {\n      id\n      completed\n      text\n      createdAt\n    }\n  }\n}\n",
+	"10967d2188b18eb59fbf584e464ea304": "query AllItems($completed: Boolean) {\n  filteredItems: items(completed: $completed) {\n    id\n    completed\n    ...ItemEntry_item\n  }\n  allItems: items {\n    id\n    completed\n  }\n}\n\nfragment ItemEntry_item on TodoItem {\n  id\n  text\n  completed\n  createdAt\n}\n",
+	"2e75b105da88343c6c346ab5f50e8ef7": "mutation AddItem($input: AddItemInput!) {\n  addItem(input: $input) {\n    error {\n      message\n    }\n  }\n}\n",
+	"aa3f58b88d49fadfd8224cfe06424002": "subscription NewItem {\n  newItem {\n    item {\n      ...All_Items_insert\n      ...Filtered_Items_insert\n      id\n    }\n  }\n}\n\nfragment All_Items_insert on TodoItem {\n  id\n  completed\n}\n\nfragment Filtered_Items_insert on TodoItem {\n  id\n  completed\n  ...ItemEntry_item\n}\n\nfragment ItemEntry_item on TodoItem {\n  id\n  text\n  completed\n  createdAt\n}\n"
+}

--- a/example/queryMap.json
+++ b/example/queryMap.json
@@ -1,9 +1,0 @@
-{
-	"e1bd3faf8b80f8206bcbbc236c4943a9": "mutation CompleteItem($id: ID!) {\n  checkItem(item: $id) {\n    item {\n      id\n      completed\n      ...Filtered_Items_remove\n    }\n  }\n}\n\nfragment Filtered_Items_remove on TodoItem {\n  id\n}\n",
-	"71fa4426fa8ba60f86d6fb0a2908c63c": "mutation UncompleteItem($id: ID!) {\n  uncheckItem(item: $id) {\n    item {\n      id\n      completed\n      ...Filtered_Items_remove\n    }\n  }\n}\n\nfragment Filtered_Items_remove on TodoItem {\n  id\n}\n",
-	"fc356a484115ab1638f9a51aae58d6ab": "mutation DeleteItem($id: ID!) {\n  deleteItem(item: $id) {\n    itemID\n  }\n}\n",
-	"2c0c4ce8b2a4ae98552ce72e6d677385": "subscription ItemUpdate($id: ID!) {\n  itemUpdate(id: $id) {\n    item {\n      id\n      completed\n      text\n      createdAt\n    }\n  }\n}\n",
-	"10967d2188b18eb59fbf584e464ea304": "query AllItems($completed: Boolean) {\n  filteredItems: items(completed: $completed) {\n    id\n    completed\n    ...ItemEntry_item\n  }\n  allItems: items {\n    id\n    completed\n  }\n}\n\nfragment ItemEntry_item on TodoItem {\n  id\n  text\n  completed\n  createdAt\n}\n",
-	"2e75b105da88343c6c346ab5f50e8ef7": "mutation AddItem($input: AddItemInput!) {\n  addItem(input: $input) {\n    error {\n      message\n    }\n  }\n}\n",
-	"aa3f58b88d49fadfd8224cfe06424002": "subscription NewItem {\n  newItem {\n    item {\n      ...All_Items_insert\n      ...Filtered_Items_insert\n      id\n    }\n  }\n}\n\nfragment All_Items_insert on TodoItem {\n  id\n  completed\n}\n\nfragment Filtered_Items_insert on TodoItem {\n  id\n  completed\n  ...ItemEntry_item\n}\n\nfragment ItemEntry_item on TodoItem {\n  id\n  text\n  completed\n  createdAt\n}\n"
-}

--- a/packages/houdini-common/src/config.ts
+++ b/packages/houdini-common/src/config.ts
@@ -38,6 +38,7 @@ export class Config {
 	schema: graphql.GraphQLSchema
 	apiUrl?: string
 	schemaPath?: string
+	outputPath?: string
 	sourceGlob: string
 	quiet: boolean
 	static?: boolean

--- a/packages/houdini-common/src/graphql.ts
+++ b/packages/houdini-common/src/graphql.ts
@@ -59,7 +59,7 @@ export function hashDocument(document: string | graphql.DocumentNode): string {
 	const docString = typeof document === 'string' ? document : graphql.print(document)
 
 	// hash the string
-	return crypto.createHash('md5').update(docString).digest('hex')
+	return crypto.createHash('sha256').update(docString).digest('hex')
 }
 
 type GraphQLParentType =

--- a/packages/houdini-preprocess/src/transforms/query.test.ts
+++ b/packages/houdini-preprocess/src/transforms/query.test.ts
@@ -6,188 +6,190 @@ describe('query preprocessor', function () {
 	test('route - preload initial data', async function () {
 		const doc = await preprocessorTest(
 			`
-			<script>
-				const { data } = query(graphql\`
-					query TestQuery {
-						viewer {
-							id
-						}
-					}
-				\`)
-			</script>
-		`
+            <script>
+                const { data } = query(graphql\`
+                    query TestQuery {
+                        viewer {
+                            id
+                        }
+                    }
+                \`)
+            </script>
+        `
 		)
 
 		// make sure we added the right stuff
 		expect(doc.module?.content).toMatchInlineSnapshot(`
-		import { convertKitPayload } from "$houdini";
-		import { fetchQuery, RequestContext } from "$houdini";
-		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
-		import { houdiniConfig } from "$houdini";
+        import { convertKitPayload } from "$houdini";
+        import { fetchQuery, RequestContext } from "$houdini";
+        import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
+        import { houdiniConfig } from "$houdini";
 
-		export async function load(context) {
-		    const _houdini_context = new RequestContext(context);
-		    const _TestQuery_Input = {};
+        export async function load(context) {
+            const _houdini_context = new RequestContext(context);
+            const _TestQuery_Input = {};
 
-		    if (!_houdini_context.continue) {
-		        return _houdini_context.returnValue;
-		    }
+            if (!_houdini_context.continue) {
+                return _houdini_context.returnValue;
+            }
 
-		    const _TestQuery = await fetchQuery(_houdini_context, {
-		        "text": _TestQueryArtifact.raw,
-		        "variables": _TestQuery_Input
-		    }, context.session);
+            const _TestQuery = await fetchQuery(_houdini_context, {
+                "hash": _TestQueryArtifact.hash,
+                "text": _TestQueryArtifact.raw,
+                "variables": _TestQuery_Input
+            }, context.session);
 
-		    if (!_TestQuery.data) {
-		        _houdini_context.graphqlErrors(_TestQuery);
-		        return _houdini_context.returnValue;
-		    }
+            if (!_TestQuery.data) {
+                _houdini_context.graphqlErrors(_TestQuery);
+                return _houdini_context.returnValue;
+            }
 
-		    return {
-		        props: {
-		            _TestQuery: _TestQuery,
-		            _TestQuery_Input: _TestQuery_Input
-		        }
-		    };
-		}
+            return {
+                props: {
+                    _TestQuery: _TestQuery,
+                    _TestQuery_Input: _TestQuery_Input
+                }
+            };
+        }
 
-		export function preload(page, session) {
-		    return convertKitPayload(this, load, page, session);
-		}
-	`)
+        export function preload(page, session) {
+            return convertKitPayload(this, load, page, session);
+        }
+    `)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
-		import { routeQuery, componentQuery, query } from "$houdini";
-		export let _TestQuery = undefined;
-		export let _TestQuery_Input = undefined;
+        import { routeQuery, componentQuery, query } from "$houdini";
+        export let _TestQuery = undefined;
+        export let _TestQuery_Input = undefined;
 
-		let _TestQuery_handler = query({
-		    "config": houdiniConfig,
-		    "initialValue": _TestQuery,
-		    "variables": _TestQuery_Input,
-		    "kind": "HoudiniQuery",
-		    "artifact": _TestQueryArtifact
-		});
+        let _TestQuery_handler = query({
+            "config": houdiniConfig,
+            "initialValue": _TestQuery,
+            "variables": _TestQuery_Input,
+            "kind": "HoudiniQuery",
+            "artifact": _TestQueryArtifact
+        });
 
-		const {
-		    data
-		} = routeQuery(_TestQuery_handler);
+        const {
+            data
+        } = routeQuery(_TestQuery_handler);
 
-		$:
-		{
-		    _TestQuery_handler.writeData(_TestQuery, _TestQuery_Input);
-		}
-	`)
+        $:
+        {
+            _TestQuery_handler.writeData(_TestQuery, _TestQuery_Input);
+        }
+    `)
 	})
 
 	test('preload initial data with variables', async function () {
 		const doc = await preprocessorTest(
 			`
-			<script context="module">
-				export function TestQueryVariables(page) {
-					return {
-						test: true
-					}
-				}
-			</script>
+            <script context="module">
+                export function TestQueryVariables(page) {
+                    return {
+                        test: true
+                    }
+                }
+            </script>
 
-			<script>
-				const { data } = query(graphql\`
-					query TestQuery($test: Boolean!) {
-						viewer {
-							id
-						}
-					}
-				\`)
-			</script>
-		`
+            <script>
+                const { data } = query(graphql\`
+                    query TestQuery($test: Boolean!) {
+                        viewer {
+                            id
+                        }
+                    }
+                \`)
+            </script>
+        `
 		)
 
 		// make sure we added the right stuff
 		expect(doc.module?.content).toMatchInlineSnapshot(`
-		import { convertKitPayload } from "$houdini";
-		import { fetchQuery, RequestContext } from "$houdini";
-		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
-		import { houdiniConfig } from "$houdini";
+        import { convertKitPayload } from "$houdini";
+        import { fetchQuery, RequestContext } from "$houdini";
+        import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
+        import { houdiniConfig } from "$houdini";
 
-		export function TestQueryVariables(page) {
-		    return {
-		        test: true
-		    };
-		}
+        export function TestQueryVariables(page) {
+            return {
+                test: true
+            };
+        }
 
-		export async function load(context) {
-		    const _houdini_context = new RequestContext(context);
+        export async function load(context) {
+            const _houdini_context = new RequestContext(context);
 
-		    const _TestQuery_Input = _houdini_context.computeInput({
-		        "config": houdiniConfig,
-		        "mode": "sapper",
-		        "variableFunction": TestQueryVariables,
-		        "artifact": _TestQueryArtifact
-		    });
+            const _TestQuery_Input = _houdini_context.computeInput({
+                "config": houdiniConfig,
+                "mode": "sapper",
+                "variableFunction": TestQueryVariables,
+                "artifact": _TestQueryArtifact
+            });
 
-		    if (!_houdini_context.continue) {
-		        return _houdini_context.returnValue;
-		    }
+            if (!_houdini_context.continue) {
+                return _houdini_context.returnValue;
+            }
 
-		    const _TestQuery = await fetchQuery(_houdini_context, {
-		        "text": _TestQueryArtifact.raw,
-		        "variables": _TestQuery_Input
-		    }, context.session);
+            const _TestQuery = await fetchQuery(_houdini_context, {
+                "hash": _TestQueryArtifact.hash,
+                "text": _TestQueryArtifact.raw,
+                "variables": _TestQuery_Input
+            }, context.session);
 
-		    if (!_TestQuery.data) {
-		        _houdini_context.graphqlErrors(_TestQuery);
-		        return _houdini_context.returnValue;
-		    }
+            if (!_TestQuery.data) {
+                _houdini_context.graphqlErrors(_TestQuery);
+                return _houdini_context.returnValue;
+            }
 
-		    return {
-		        props: {
-		            _TestQuery: _TestQuery,
-		            _TestQuery_Input: _TestQuery_Input
-		        }
-		    };
-		}
+            return {
+                props: {
+                    _TestQuery: _TestQuery,
+                    _TestQuery_Input: _TestQuery_Input
+                }
+            };
+        }
 
-		export function preload(page, session) {
-		    return convertKitPayload(this, load, page, session);
-		}
-	`)
+        export function preload(page, session) {
+            return convertKitPayload(this, load, page, session);
+        }
+    `)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
-		import { routeQuery, componentQuery, query } from "$houdini";
-		export let _TestQuery = undefined;
-		export let _TestQuery_Input = undefined;
+        import { routeQuery, componentQuery, query } from "$houdini";
+        export let _TestQuery = undefined;
+        export let _TestQuery_Input = undefined;
 
-		let _TestQuery_handler = query({
-		    "config": houdiniConfig,
-		    "initialValue": _TestQuery,
-		    "variables": _TestQuery_Input,
-		    "kind": "HoudiniQuery",
-		    "artifact": _TestQueryArtifact
-		});
+        let _TestQuery_handler = query({
+            "config": houdiniConfig,
+            "initialValue": _TestQuery,
+            "variables": _TestQuery_Input,
+            "kind": "HoudiniQuery",
+            "artifact": _TestQueryArtifact
+        });
 
-		const {
-		    data
-		} = routeQuery(_TestQuery_handler);
+        const {
+            data
+        } = routeQuery(_TestQuery_handler);
 
-		$:
-		{
-		    _TestQuery_handler.writeData(_TestQuery, _TestQuery_Input);
-		}
-	`)
+        $:
+        {
+            _TestQuery_handler.writeData(_TestQuery, _TestQuery_Input);
+        }
+    `)
 	})
 
 	test('sveltekit', async function () {
 		const doc = await preprocessorTest(
 			`
-			<script>
-				const { data } = query(graphql\`
-					query TestQuery {
-						viewer {
-							id
-						}
-					}
-				\`)
-			</script>
-		`,
+            <script>
+                const { data } = query(graphql\`
+                    query TestQuery {
+                        viewer {
+                            id
+                        }
+                    }
+                \`)
+            </script>
+        `,
 			{
 				mode: 'kit',
 				route: true,
@@ -196,73 +198,74 @@ describe('query preprocessor', function () {
 
 		// make sure we added the right stuff
 		expect(doc.module?.content).toMatchInlineSnapshot(`
-		import { fetchQuery, RequestContext } from "$houdini";
-		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
-		import { houdiniConfig } from "$houdini";
+        import { fetchQuery, RequestContext } from "$houdini";
+        import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
+        import { houdiniConfig } from "$houdini";
 
-		export async function load(context) {
-		    const _houdini_context = new RequestContext(context);
-		    const _TestQuery_Input = {};
+        export async function load(context) {
+            const _houdini_context = new RequestContext(context);
+            const _TestQuery_Input = {};
 
-		    if (!_houdini_context.continue) {
-		        return _houdini_context.returnValue;
-		    }
+            if (!_houdini_context.continue) {
+                return _houdini_context.returnValue;
+            }
 
-		    const _TestQuery = await fetchQuery(_houdini_context, {
-		        "text": _TestQueryArtifact.raw,
-		        "variables": _TestQuery_Input
-		    }, context.session);
+            const _TestQuery = await fetchQuery(_houdini_context, {
+                "hash": _TestQueryArtifact.hash,
+                "text": _TestQueryArtifact.raw,
+                "variables": _TestQuery_Input
+            }, context.session);
 
-		    if (!_TestQuery.data) {
-		        _houdini_context.graphqlErrors(_TestQuery);
-		        return _houdini_context.returnValue;
-		    }
+            if (!_TestQuery.data) {
+                _houdini_context.graphqlErrors(_TestQuery);
+                return _houdini_context.returnValue;
+            }
 
-		    return {
-		        props: {
-		            _TestQuery: _TestQuery,
-		            _TestQuery_Input: _TestQuery_Input
-		        }
-		    };
-		}
-	`)
+            return {
+                props: {
+                    _TestQuery: _TestQuery,
+                    _TestQuery_Input: _TestQuery_Input
+                }
+            };
+        }
+    `)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
-		import { routeQuery, componentQuery, query } from "$houdini";
-		export let _TestQuery = undefined;
-		export let _TestQuery_Input = undefined;
+        import { routeQuery, componentQuery, query } from "$houdini";
+        export let _TestQuery = undefined;
+        export let _TestQuery_Input = undefined;
 
-		let _TestQuery_handler = query({
-		    "config": houdiniConfig,
-		    "initialValue": _TestQuery,
-		    "variables": _TestQuery_Input,
-		    "kind": "HoudiniQuery",
-		    "artifact": _TestQueryArtifact
-		});
+        let _TestQuery_handler = query({
+            "config": houdiniConfig,
+            "initialValue": _TestQuery,
+            "variables": _TestQuery_Input,
+            "kind": "HoudiniQuery",
+            "artifact": _TestQueryArtifact
+        });
 
-		const {
-		    data
-		} = routeQuery(_TestQuery_handler);
+        const {
+            data
+        } = routeQuery(_TestQuery_handler);
 
-		$:
-		{
-		    _TestQuery_handler.writeData(_TestQuery, _TestQuery_Input);
-		}
-	`)
+        $:
+        {
+            _TestQuery_handler.writeData(_TestQuery, _TestQuery_Input);
+        }
+    `)
 	})
 
 	test('svelte kit with static set', async function () {
 		const doc = await preprocessorTest(
 			`
-			<script>
-				const { data } = query(graphql\`
-					query TestQuery {
-						viewer {
-							id
-						}
-					}
-				\`)
-			</script>
-		`,
+            <script>
+                const { data } = query(graphql\`
+                    query TestQuery {
+                        viewer {
+                            id
+                        }
+                    }
+                \`)
+            </script>
+        `,
 			{
 				mode: 'kit',
 				// if we are in a route but static is set to true, we need to treat the file like a
@@ -277,44 +280,44 @@ describe('query preprocessor', function () {
 			`import { houdiniConfig } from "$houdini";`
 		)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
-		import { routeQuery, componentQuery, query } from "$houdini";
-		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
-		export let _TestQuery = undefined;
-		export let _TestQuery_Input = undefined;
+        import { routeQuery, componentQuery, query } from "$houdini";
+        import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
+        export let _TestQuery = undefined;
+        export let _TestQuery_Input = undefined;
 
-		let _TestQuery_handler = query({
-		    "config": houdiniConfig,
-		    "initialValue": _TestQuery,
-		    "variables": _TestQuery_Input,
-		    "kind": "HoudiniQuery",
-		    "artifact": _TestQueryArtifact
-		});
+        let _TestQuery_handler = query({
+            "config": houdiniConfig,
+            "initialValue": _TestQuery,
+            "variables": _TestQuery_Input,
+            "kind": "HoudiniQuery",
+            "artifact": _TestQueryArtifact
+        });
 
-		const {
-		    data
-		} = componentQuery({
-		    queryHandler: _TestQuery_handler,
-		    config: houdiniConfig,
-		    artifact: _TestQueryArtifact,
-		    variableFunction: null,
-		    getProps: () => $$props
-		});
-	`)
+        const {
+            data
+        } = componentQuery({
+            queryHandler: _TestQuery_handler,
+            config: houdiniConfig,
+            artifact: _TestQueryArtifact,
+            variableFunction: null,
+            getProps: () => $$props
+        });
+    `)
 	})
 
 	test('non-route page - no variables', async function () {
 		const doc = await preprocessorTest(
 			`
-			<script>
-				const { data } = query(graphql\`
-					query TestQuery {
-						viewer {
-							id
-						}
-					}
-				\`)
-			</script>
-		`,
+            <script>
+                const { data } = query(graphql\`
+                    query TestQuery {
+                        viewer {
+                            id
+                        }
+                    }
+                \`)
+            </script>
+        `,
 			{
 				mode: 'kit',
 				route: false,
@@ -326,44 +329,44 @@ describe('query preprocessor', function () {
 			`import { houdiniConfig } from "$houdini";`
 		)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
-		import { routeQuery, componentQuery, query } from "$houdini";
-		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
-		export let _TestQuery = undefined;
-		export let _TestQuery_Input = undefined;
+        import { routeQuery, componentQuery, query } from "$houdini";
+        import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
+        export let _TestQuery = undefined;
+        export let _TestQuery_Input = undefined;
 
-		let _TestQuery_handler = query({
-		    "config": houdiniConfig,
-		    "initialValue": _TestQuery,
-		    "variables": _TestQuery_Input,
-		    "kind": "HoudiniQuery",
-		    "artifact": _TestQueryArtifact
-		});
+        let _TestQuery_handler = query({
+            "config": houdiniConfig,
+            "initialValue": _TestQuery,
+            "variables": _TestQuery_Input,
+            "kind": "HoudiniQuery",
+            "artifact": _TestQueryArtifact
+        });
 
-		const {
-		    data
-		} = componentQuery({
-		    queryHandler: _TestQuery_handler,
-		    config: houdiniConfig,
-		    artifact: _TestQueryArtifact,
-		    variableFunction: null,
-		    getProps: () => $$props
-		});
-	`)
+        const {
+            data
+        } = componentQuery({
+            queryHandler: _TestQuery_handler,
+            config: houdiniConfig,
+            artifact: _TestQueryArtifact,
+            variableFunction: null,
+            getProps: () => $$props
+        });
+    `)
 	})
 
 	test('non-route page - with variables', async function () {
 		const doc = await preprocessorTest(
 			`
-			<script>
-				const { data } = query(graphql\`
-					query TestQuery($test: String!) {
-						users(stringValue: $test) {
-							id
-						}
-					}
-				\`)
-			</script>
-		`,
+            <script>
+                const { data } = query(graphql\`
+                    query TestQuery($test: String!) {
+                        users(stringValue: $test) {
+                            id
+                        }
+                    }
+                \`)
+            </script>
+        `,
 			{
 				mode: 'kit',
 				route: false,
@@ -375,44 +378,44 @@ describe('query preprocessor', function () {
 			`import { houdiniConfig } from "$houdini";`
 		)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
-		import { routeQuery, componentQuery, query } from "$houdini";
-		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
-		export let _TestQuery = undefined;
-		export let _TestQuery_Input = undefined;
+        import { routeQuery, componentQuery, query } from "$houdini";
+        import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
+        export let _TestQuery = undefined;
+        export let _TestQuery_Input = undefined;
 
-		let _TestQuery_handler = query({
-		    "config": houdiniConfig,
-		    "initialValue": _TestQuery,
-		    "variables": _TestQuery_Input,
-		    "kind": "HoudiniQuery",
-		    "artifact": _TestQueryArtifact
-		});
+        let _TestQuery_handler = query({
+            "config": houdiniConfig,
+            "initialValue": _TestQuery,
+            "variables": _TestQuery_Input,
+            "kind": "HoudiniQuery",
+            "artifact": _TestQueryArtifact
+        });
 
-		const {
-		    data
-		} = componentQuery({
-		    queryHandler: _TestQuery_handler,
-		    config: houdiniConfig,
-		    artifact: _TestQueryArtifact,
-		    variableFunction: TestQueryVariables,
-		    getProps: () => $$props
-		});
-	`)
+        const {
+            data
+        } = componentQuery({
+            queryHandler: _TestQuery_handler,
+            config: houdiniConfig,
+            artifact: _TestQueryArtifact,
+            variableFunction: TestQueryVariables,
+            getProps: () => $$props
+        });
+    `)
 	})
 
 	test('bare svelte component in route filepath', async function () {
 		const doc = await preprocessorTest(
 			`
-			<script>
-				const { data } = query(graphql\`
-					query TestQuery {
-						viewer {
-							id
-						}
-					}
-				\`)
-			</script>
-		`,
+            <script>
+                const { data } = query(graphql\`
+                    query TestQuery {
+                        viewer {
+                            id
+                        }
+                    }
+                \`)
+            </script>
+        `,
 			{
 				framework: 'svelte',
 				route: true,
@@ -424,29 +427,29 @@ describe('query preprocessor', function () {
 			`import { houdiniConfig } from "$houdini";`
 		)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
-		import { routeQuery, componentQuery, query } from "$houdini";
-		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
-		export let _TestQuery = undefined;
-		export let _TestQuery_Input = undefined;
+        import { routeQuery, componentQuery, query } from "$houdini";
+        import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
+        export let _TestQuery = undefined;
+        export let _TestQuery_Input = undefined;
 
-		let _TestQuery_handler = query({
-		    "config": houdiniConfig,
-		    "initialValue": _TestQuery,
-		    "variables": _TestQuery_Input,
-		    "kind": "HoudiniQuery",
-		    "artifact": _TestQueryArtifact
-		});
+        let _TestQuery_handler = query({
+            "config": houdiniConfig,
+            "initialValue": _TestQuery,
+            "variables": _TestQuery_Input,
+            "kind": "HoudiniQuery",
+            "artifact": _TestQueryArtifact
+        });
 
-		const {
-		    data
-		} = componentQuery({
-		    queryHandler: _TestQuery_handler,
-		    config: houdiniConfig,
-		    artifact: _TestQueryArtifact,
-		    variableFunction: null,
-		    getProps: () => $$props
-		});
-	`)
+        const {
+            data
+        } = componentQuery({
+            queryHandler: _TestQuery_handler,
+            config: houdiniConfig,
+            artifact: _TestQueryArtifact,
+            variableFunction: null,
+            getProps: () => $$props
+        });
+    `)
 	})
 
 	test.todo('fails if variable function is not present')

--- a/packages/houdini-preprocess/src/transforms/query.ts
+++ b/packages/houdini-preprocess/src/transforms/query.ts
@@ -425,6 +425,13 @@ function addKitLoad(config: Config, body: Statement[], queries: EmbeddedGraphqlD
 							requestContext,
 							AST.objectExpression([
 								AST.objectProperty(
+									AST.literal('hash'),
+									AST.memberExpression(
+										AST.identifier(artifactIdentifier(document.artifact)),
+										AST.identifier('hash')
+									)
+								),
+								AST.objectProperty(
 									AST.literal('text'),
 									AST.memberExpression(
 										AST.identifier(artifactIdentifier(document.artifact)),

--- a/packages/houdini/cmd/generate.ts
+++ b/packages/houdini/cmd/generate.ts
@@ -44,6 +44,7 @@ export const runPipeline = async (config: Config, docs: CollectedGraphQLDocument
 			generators.artifacts,
 			generators.runtime,
 			generators.typescript,
+			generators.persistOutput,
 		],
 		docs
 	)

--- a/packages/houdini/cmd/generators/artifacts/artifacts.test.ts
+++ b/packages/houdini/cmd/generators/artifacts/artifacts.test.ts
@@ -47,25 +47,26 @@ test('adds kind, name, and raw, response, and selection', async function () {
 	}).program
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "TestQuery",
-		    kind: "HoudiniQuery",
+        module.exports = {
+            name: "TestQuery",
+            kind: "HoudiniQuery",
+            hash: "8e483259f3d69f416c01b6106c0440fa0f916abb4cadb75273f8226a1ff0a5e2",
 
-		    raw: \`query TestQuery {
-		  version
-		}
-		\`,
+            raw: \`query TestQuery {
+          version
+        }
+        \`,
 
-		    rootType: "Query",
+            rootType: "Query",
 
-		    selection: {
-		        "version": {
-		            "type": "Int",
-		            "keyRaw": "version"
-		        }
-		    }
-		};
-	`)
+            selection: {
+                "version": {
+                    "type": "Int",
+                    "keyRaw": "version"
+                }
+            }
+        };
+    `)
 
 	const fragmentContents = await fs.readFile(
 		path.join(config.artifactPath(docs[1].document)),
@@ -78,25 +79,26 @@ test('adds kind, name, and raw, response, and selection', async function () {
 	}).program
 	// and verify their content
 	expect(parsedFragment).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "TestFragment",
-		    kind: "HoudiniFragment",
+        module.exports = {
+            name: "TestFragment",
+            kind: "HoudiniFragment",
+            hash: "29c40b5d9f6b0cd77fc3fb46fc1338be4960369a01651d5149c2442a33b48686",
 
-		    raw: \`fragment TestFragment on User {
-		  firstName
-		}
-		\`,
+            raw: \`fragment TestFragment on User {
+          firstName
+        }
+        \`,
 
-		    rootType: "User",
+            rootType: "User",
 
-		    selection: {
-		        "firstName": {
-		            "type": "String",
-		            "keyRaw": "firstName"
-		        }
-		    }
-		};
-	`)
+            selection: {
+                "firstName": {
+                    "type": "String",
+                    "keyRaw": "firstName"
+                }
+            }
+        };
+    `)
 })
 
 test('selection includes fragments', async function () {
@@ -122,44 +124,45 @@ test('selection includes fragments', async function () {
 	}).program
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "TestQuery",
-		    kind: "HoudiniQuery",
+        module.exports = {
+            name: "TestQuery",
+            kind: "HoudiniQuery",
+            hash: "2d52c61126b6514cd0f51584ae220d583c1df1db1090d2b44da83b7f59a4022c",
 
-		    raw: \`query TestQuery {
-		  user {
-		    ...TestFragment
-		    id
-		  }
-		}
+            raw: \`query TestQuery {
+          user {
+            ...TestFragment
+            id
+          }
+        }
 
-		fragment TestFragment on User {
-		  firstName
-		}
-		\`,
+        fragment TestFragment on User {
+          firstName
+        }
+        \`,
 
-		    rootType: "Query",
+            rootType: "Query",
 
-		    selection: {
-		        "user": {
-		            "type": "User",
-		            "keyRaw": "user",
+            selection: {
+                "user": {
+                    "type": "User",
+                    "keyRaw": "user",
 
-		            "fields": {
-		                "firstName": {
-		                    "type": "String",
-		                    "keyRaw": "firstName"
-		                },
+                    "fields": {
+                        "firstName": {
+                            "type": "String",
+                            "keyRaw": "firstName"
+                        },
 
-		                "id": {
-		                    "type": "ID",
-		                    "keyRaw": "id"
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                        "id": {
+                            "type": "ID",
+                            "keyRaw": "id"
+                        }
+                    }
+                }
+            }
+        };
+    `)
 
 	const fragmentContents = await fs.readFile(
 		path.join(config.artifactPath(docs[1].document)),
@@ -172,25 +175,26 @@ test('selection includes fragments', async function () {
 	}).program
 	// and verify their content
 	expect(parsedFragment).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "TestFragment",
-		    kind: "HoudiniFragment",
+        module.exports = {
+            name: "TestFragment",
+            kind: "HoudiniFragment",
+            hash: "29c40b5d9f6b0cd77fc3fb46fc1338be4960369a01651d5149c2442a33b48686",
 
-		    raw: \`fragment TestFragment on User {
-		  firstName
-		}
-		\`,
+            raw: \`fragment TestFragment on User {
+          firstName
+        }
+        \`,
 
-		    rootType: "User",
+            rootType: "User",
 
-		    selection: {
-		        "firstName": {
-		            "type": "String",
-		            "keyRaw": "firstName"
-		        }
-		    }
-		};
-	`)
+            selection: {
+                "firstName": {
+                    "type": "String",
+                    "keyRaw": "firstName"
+                }
+            }
+        };
+    `)
 })
 
 test('internal directives are scrubbed', async function () {
@@ -212,44 +216,45 @@ test('internal directives are scrubbed', async function () {
 	}).program
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "TestQuery",
-		    kind: "HoudiniQuery",
+        module.exports = {
+            name: "TestQuery",
+            kind: "HoudiniQuery",
+            hash: "d602ba63b61c244225db2524918578e52cc0c1b06a512b56064deb7d176f8e30",
 
-		    raw: \`query TestQuery {
-		  user {
-		    ...A
-		    id
-		  }
-		}
+            raw: \`query TestQuery {
+          user {
+            ...A
+            id
+          }
+        }
 
-		fragment A on User {
-		  firstName
-		}
-		\`,
+        fragment A on User {
+          firstName
+        }
+        \`,
 
-		    rootType: "Query",
+            rootType: "Query",
 
-		    selection: {
-		        "user": {
-		            "type": "User",
-		            "keyRaw": "user",
+            selection: {
+                "user": {
+                    "type": "User",
+                    "keyRaw": "user",
 
-		            "fields": {
-		                "firstName": {
-		                    "type": "String",
-		                    "keyRaw": "firstName"
-		                },
+                    "fields": {
+                        "firstName": {
+                            "type": "String",
+                            "keyRaw": "firstName"
+                        },
 
-		                "id": {
-		                    "type": "ID",
-		                    "keyRaw": "id"
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                        "id": {
+                            "type": "ID",
+                            "keyRaw": "id"
+                        }
+                    }
+                }
+            }
+        };
+    `)
 })
 
 test('overlapping query and fragment selection', async function () {
@@ -271,45 +276,46 @@ test('overlapping query and fragment selection', async function () {
 	}).program
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "TestQuery",
-		    kind: "HoudiniQuery",
+        module.exports = {
+            name: "TestQuery",
+            kind: "HoudiniQuery",
+            hash: "89ff86b7807db8c5395ab994977ca62e2af6a50b78add45f306d6730faa17cdf",
 
-		    raw: \`query TestQuery {
-		  user {
-		    firstName
-		    ...A
-		    id
-		  }
-		}
+            raw: \`query TestQuery {
+          user {
+            firstName
+            ...A
+            id
+          }
+        }
 
-		fragment A on User {
-		  firstName
-		}
-		\`,
+        fragment A on User {
+          firstName
+        }
+        \`,
 
-		    rootType: "Query",
+            rootType: "Query",
 
-		    selection: {
-		        "user": {
-		            "type": "User",
-		            "keyRaw": "user",
+            selection: {
+                "user": {
+                    "type": "User",
+                    "keyRaw": "user",
 
-		            "fields": {
-		                "firstName": {
-		                    "type": "String",
-		                    "keyRaw": "firstName"
-		                },
+                    "fields": {
+                        "firstName": {
+                            "type": "String",
+                            "keyRaw": "firstName"
+                        },
 
-		                "id": {
-		                    "type": "ID",
-		                    "keyRaw": "id"
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                        "id": {
+                            "type": "ID",
+                            "keyRaw": "id"
+                        }
+                    }
+                }
+            }
+        };
+    `)
 })
 
 test('overlapping query and fragment nested selection', async function () {
@@ -331,62 +337,63 @@ test('overlapping query and fragment nested selection', async function () {
 	}).program
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "TestQuery",
-		    kind: "HoudiniQuery",
+        module.exports = {
+            name: "TestQuery",
+            kind: "HoudiniQuery",
+            hash: "58b9fbe10de1dedb58d303b2e492b01192c69daceafd1060e433f40f9b4d6eb0",
 
-		    raw: \`query TestQuery {
-		  user {
-		    friends {
-		      firstName
-		      id
-		    }
-		    ...A
-		    id
-		  }
-		}
+            raw: \`query TestQuery {
+          user {
+            friends {
+              firstName
+              id
+            }
+            ...A
+            id
+          }
+        }
 
-		fragment A on User {
-		  friends {
-		    id
-		  }
-		}
-		\`,
+        fragment A on User {
+          friends {
+            id
+          }
+        }
+        \`,
 
-		    rootType: "Query",
+            rootType: "Query",
 
-		    selection: {
-		        "user": {
-		            "type": "User",
-		            "keyRaw": "user",
+            selection: {
+                "user": {
+                    "type": "User",
+                    "keyRaw": "user",
 
-		            "fields": {
-		                "friends": {
-		                    "type": "User",
-		                    "keyRaw": "friends",
+                    "fields": {
+                        "friends": {
+                            "type": "User",
+                            "keyRaw": "friends",
 
-		                    "fields": {
-		                        "firstName": {
-		                            "type": "String",
-		                            "keyRaw": "firstName"
-		                        },
+                            "fields": {
+                                "firstName": {
+                                    "type": "String",
+                                    "keyRaw": "firstName"
+                                },
 
-		                        "id": {
-		                            "type": "ID",
-		                            "keyRaw": "id"
-		                        }
-		                    }
-		                },
+                                "id": {
+                                    "type": "ID",
+                                    "keyRaw": "id"
+                                }
+                            }
+                        },
 
-		                "id": {
-		                    "type": "ID",
-		                    "keyRaw": "id"
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                        "id": {
+                            "type": "ID",
+                            "keyRaw": "id"
+                        }
+                    }
+                }
+            }
+        };
+    `)
 })
 
 test('selections with interfaces', async function () {
@@ -394,18 +401,18 @@ test('selections with interfaces', async function () {
 	const mutationDocs = [
 		mockCollectedDoc(
 			`query Friends {
-					friends {
+                    friends {
                         ... on Cat {
                             id
-							owner {
-								firstName
-							}
+                            owner {
+                                firstName
+                            }
                         }
                         ... on Ghost {
                             name
                         }
-					}
-				}`
+                    }
+                }`
 		),
 	]
 
@@ -424,73 +431,74 @@ test('selections with interfaces', async function () {
 	}).program
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		export default {
-		    name: "Friends",
-		    kind: "HoudiniQuery",
+        export default {
+            name: "Friends",
+            kind: "HoudiniQuery",
+            hash: "359c4d6ceae8e5a5411fa160c2ffaf61e714d7c82a0f1816244f8a83291a2863",
 
-		    raw: \`query Friends {
-		  friends {
-		    ... on Cat {
-		      id
-		      owner {
-		        firstName
-		        id
-		      }
-		    }
-		    ... on Ghost {
-		      name
-		    }
-		    __typename
-		  }
-		}
-		\`,
+            raw: \`query Friends {
+          friends {
+            ... on Cat {
+              id
+              owner {
+                firstName
+                id
+              }
+            }
+            ... on Ghost {
+              name
+            }
+            __typename
+          }
+        }
+        \`,
 
-		    rootType: "Query",
+            rootType: "Query",
 
-		    selection: {
-		        "friends": {
-		            "type": "Friend",
-		            "keyRaw": "friends",
+            selection: {
+                "friends": {
+                    "type": "Friend",
+                    "keyRaw": "friends",
 
-		            "fields": {
-		                "id": {
-		                    "type": "ID",
-		                    "keyRaw": "id"
-		                },
+                    "fields": {
+                        "id": {
+                            "type": "ID",
+                            "keyRaw": "id"
+                        },
 
-		                "owner": {
-		                    "type": "User",
-		                    "keyRaw": "owner",
+                        "owner": {
+                            "type": "User",
+                            "keyRaw": "owner",
 
-		                    "fields": {
-		                        "firstName": {
-		                            "type": "String",
-		                            "keyRaw": "firstName"
-		                        },
+                            "fields": {
+                                "firstName": {
+                                    "type": "String",
+                                    "keyRaw": "firstName"
+                                },
 
-		                        "id": {
-		                            "type": "ID",
-		                            "keyRaw": "id"
-		                        }
-		                    }
-		                },
+                                "id": {
+                                    "type": "ID",
+                                    "keyRaw": "id"
+                                }
+                            }
+                        },
 
-		                "name": {
-		                    "type": "String",
-		                    "keyRaw": "name"
-		                },
+                        "name": {
+                            "type": "String",
+                            "keyRaw": "name"
+                        },
 
-		                "__typename": {
-		                    "type": "String",
-		                    "keyRaw": "__typename"
-		                }
-		            },
+                        "__typename": {
+                            "type": "String",
+                            "keyRaw": "__typename"
+                        }
+                    },
 
-		            "abstract": true
-		        }
-		    }
-		};
-	`)
+                    "abstract": true
+                }
+            }
+        };
+    `)
 })
 
 test('selections with unions', async function () {
@@ -498,18 +506,18 @@ test('selections with unions', async function () {
 	const mutationDocs = [
 		mockCollectedDoc(
 			`query Friends {
-					entities {
+                    entities {
                         ... on Cat {
                             id
-							owner {
-								firstName
-							}
+                            owner {
+                                firstName
+                            }
                         }
                         ... on Ghost {
                             name
                         }
-					}
-				}`
+                    }
+                }`
 		),
 	]
 
@@ -528,73 +536,74 @@ test('selections with unions', async function () {
 	}).program
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		export default {
-		    name: "Friends",
-		    kind: "HoudiniQuery",
+        export default {
+            name: "Friends",
+            kind: "HoudiniQuery",
+            hash: "512c81f0e5ea88525b407c9978620c931d4e8bc41317d9bd6eeaf3338fe40c6c",
 
-		    raw: \`query Friends {
-		  entities {
-		    ... on Cat {
-		      id
-		      owner {
-		        firstName
-		        id
-		      }
-		    }
-		    ... on Ghost {
-		      name
-		    }
-		    __typename
-		  }
-		}
-		\`,
+            raw: \`query Friends {
+          entities {
+            ... on Cat {
+              id
+              owner {
+                firstName
+                id
+              }
+            }
+            ... on Ghost {
+              name
+            }
+            __typename
+          }
+        }
+        \`,
 
-		    rootType: "Query",
+            rootType: "Query",
 
-		    selection: {
-		        "entities": {
-		            "type": "Entity",
-		            "keyRaw": "entities",
+            selection: {
+                "entities": {
+                    "type": "Entity",
+                    "keyRaw": "entities",
 
-		            "fields": {
-		                "id": {
-		                    "type": "ID",
-		                    "keyRaw": "id"
-		                },
+                    "fields": {
+                        "id": {
+                            "type": "ID",
+                            "keyRaw": "id"
+                        },
 
-		                "owner": {
-		                    "type": "User",
-		                    "keyRaw": "owner",
+                        "owner": {
+                            "type": "User",
+                            "keyRaw": "owner",
 
-		                    "fields": {
-		                        "firstName": {
-		                            "type": "String",
-		                            "keyRaw": "firstName"
-		                        },
+                            "fields": {
+                                "firstName": {
+                                    "type": "String",
+                                    "keyRaw": "firstName"
+                                },
 
-		                        "id": {
-		                            "type": "ID",
-		                            "keyRaw": "id"
-		                        }
-		                    }
-		                },
+                                "id": {
+                                    "type": "ID",
+                                    "keyRaw": "id"
+                                }
+                            }
+                        },
 
-		                "name": {
-		                    "type": "String",
-		                    "keyRaw": "name"
-		                },
+                        "name": {
+                            "type": "String",
+                            "keyRaw": "name"
+                        },
 
-		                "__typename": {
-		                    "type": "String",
-		                    "keyRaw": "__typename"
-		                }
-		            },
+                        "__typename": {
+                            "type": "String",
+                            "keyRaw": "__typename"
+                        }
+                    },
 
-		            "abstract": true
-		        }
-		    }
-		};
-	`)
+                    "abstract": true
+                }
+            }
+        };
+    `)
 })
 
 describe('mutation artifacts', function () {
@@ -604,19 +613,19 @@ describe('mutation artifacts', function () {
 		const mutationDocs = [
 			mockCollectedDoc(
 				`mutation B {
-					addFriend {
-						friend {
-							firstName
-						}
-					}
-				}`
+                    addFriend {
+                        friend {
+                            firstName
+                        }
+                    }
+                }`
 			),
 			mockCollectedDoc(
 				`query TestQuery {
-					users(stringValue: "foo") @list(name: "All_Users") {
-						firstName
-					}
-				}`
+                    users(stringValue: "foo") @list(name: "All_Users") {
+                        firstName
+                    }
+                }`
 			),
 		]
 
@@ -635,68 +644,69 @@ describe('mutation artifacts', function () {
 		}).program
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
-		export default {
-		    name: "B",
-		    kind: "HoudiniMutation",
+        export default {
+            name: "B",
+            kind: "HoudiniMutation",
+            hash: "38005b47351eb4e6e14e3c13a8d0d206dac09bf80d6fa3c103a060a3990edd37",
 
-		    raw: \`mutation B {
-		  addFriend {
-		    friend {
-		      firstName
-		      id
-		    }
-		  }
-		}
-		\`,
+            raw: \`mutation B {
+          addFriend {
+            friend {
+              firstName
+              id
+            }
+          }
+        }
+        \`,
 
-		    rootType: "Mutation",
+            rootType: "Mutation",
 
-		    selection: {
-		        "addFriend": {
-		            "type": "AddFriendOutput",
-		            "keyRaw": "addFriend",
+            selection: {
+                "addFriend": {
+                    "type": "AddFriendOutput",
+                    "keyRaw": "addFriend",
 
-		            "fields": {
-		                "friend": {
-		                    "type": "User",
-		                    "keyRaw": "friend",
+                    "fields": {
+                        "friend": {
+                            "type": "User",
+                            "keyRaw": "friend",
 
-		                    "fields": {
-		                        "firstName": {
-		                            "type": "String",
-		                            "keyRaw": "firstName"
-		                        },
+                            "fields": {
+                                "firstName": {
+                                    "type": "String",
+                                    "keyRaw": "firstName"
+                                },
 
-		                        "id": {
-		                            "type": "ID",
-		                            "keyRaw": "id"
-		                        }
-		                    }
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                                "id": {
+                                    "type": "ID",
+                                    "keyRaw": "id"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    `)
 	})
 
 	test('insert operation', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
 				`mutation A {
-					addFriend {
-						friend {
-							...All_Users_insert
-						}
-					}
-				}`
+                    addFriend {
+                        friend {
+                            ...All_Users_insert
+                        }
+                    }
+                }`
 			),
 			mockCollectedDoc(
 				`query TestQuery {
-					users(stringValue: "foo") @list(name: "All_Users") {
-						firstName
-					}
-				}`
+                    users(stringValue: "foo") @list(name: "All_Users") {
+                        firstName
+                    }
+                }`
 			),
 		]
 
@@ -715,79 +725,80 @@ describe('mutation artifacts', function () {
 		}).program
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "A",
-		    kind: "HoudiniMutation",
+        module.exports = {
+            name: "A",
+            kind: "HoudiniMutation",
+            hash: "7cc5c23ffd19603e2c7c727d1ac2726d4d87ee6b0470ced7d28c7f0ed88a05c2",
 
-		    raw: \`mutation A {
-		  addFriend {
-		    friend {
-		      ...All_Users_insert
-		      id
-		    }
-		  }
-		}
+            raw: \`mutation A {
+          addFriend {
+            friend {
+              ...All_Users_insert
+              id
+            }
+          }
+        }
 
-		fragment All_Users_insert on User {
-		  firstName
-		  id
-		}
-		\`,
+        fragment All_Users_insert on User {
+          firstName
+          id
+        }
+        \`,
 
-		    rootType: "Mutation",
+            rootType: "Mutation",
 
-		    selection: {
-		        "addFriend": {
-		            "type": "AddFriendOutput",
-		            "keyRaw": "addFriend",
+            selection: {
+                "addFriend": {
+                    "type": "AddFriendOutput",
+                    "keyRaw": "addFriend",
 
-		            "fields": {
-		                "friend": {
-		                    "type": "User",
-		                    "keyRaw": "friend",
+                    "fields": {
+                        "friend": {
+                            "type": "User",
+                            "keyRaw": "friend",
 
-		                    "fields": {
-		                        "firstName": {
-		                            "type": "String",
-		                            "keyRaw": "firstName"
-		                        },
+                            "fields": {
+                                "firstName": {
+                                    "type": "String",
+                                    "keyRaw": "firstName"
+                                },
 
-		                        "id": {
-		                            "type": "ID",
-		                            "keyRaw": "id"
-		                        }
-		                    },
+                                "id": {
+                                    "type": "ID",
+                                    "keyRaw": "id"
+                                }
+                            },
 
-		                    "operations": [{
-		                        "action": "insert",
-		                        "list": "All_Users",
-		                        "position": "last"
-		                    }]
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                            "operations": [{
+                                "action": "insert",
+                                "list": "All_Users",
+                                "position": "last"
+                            }]
+                        }
+                    }
+                }
+            }
+        };
+    `)
 	})
 
 	test('remove operation', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
 				`mutation A {
-					addFriend {
-						friend {
-							...All_Users_remove
-						}
-					}
-				}`
+                    addFriend {
+                        friend {
+                            ...All_Users_remove
+                        }
+                    }
+                }`
 			),
 			mockCollectedDoc(
 				`query TestQuery {
-					users(stringValue: "foo") @list(name: "All_Users") {
-						firstName
-					}
-				}`
+                    users(stringValue: "foo") @list(name: "All_Users") {
+                        firstName
+                    }
+                }`
 			),
 		]
 
@@ -806,70 +817,71 @@ describe('mutation artifacts', function () {
 		}).program
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "A",
-		    kind: "HoudiniMutation",
+        module.exports = {
+            name: "A",
+            kind: "HoudiniMutation",
+            hash: "9dc41329a7176f813b623958a68c2752d391151a4f3b1f9b8198f6c487e931a4",
 
-		    raw: \`mutation A {
-		  addFriend {
-		    friend {
-		      ...All_Users_remove
-		      id
-		    }
-		  }
-		}
+            raw: \`mutation A {
+          addFriend {
+            friend {
+              ...All_Users_remove
+              id
+            }
+          }
+        }
 
-		fragment All_Users_remove on User {
-		  id
-		}
-		\`,
+        fragment All_Users_remove on User {
+          id
+        }
+        \`,
 
-		    rootType: "Mutation",
+            rootType: "Mutation",
 
-		    selection: {
-		        "addFriend": {
-		            "type": "AddFriendOutput",
-		            "keyRaw": "addFriend",
+            selection: {
+                "addFriend": {
+                    "type": "AddFriendOutput",
+                    "keyRaw": "addFriend",
 
-		            "fields": {
-		                "friend": {
-		                    "type": "User",
-		                    "keyRaw": "friend",
+                    "fields": {
+                        "friend": {
+                            "type": "User",
+                            "keyRaw": "friend",
 
-		                    "fields": {
-		                        "id": {
-		                            "type": "ID",
-		                            "keyRaw": "id"
-		                        }
-		                    },
+                            "fields": {
+                                "id": {
+                                    "type": "ID",
+                                    "keyRaw": "id"
+                                }
+                            },
 
-		                    "operations": [{
-		                        "action": "remove",
-		                        "list": "All_Users"
-		                    }]
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                            "operations": [{
+                                "action": "remove",
+                                "list": "All_Users"
+                            }]
+                        }
+                    }
+                }
+            }
+        };
+    `)
 	})
 
 	test('delete operation', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
 				`mutation A {
-					deleteUser(id: "1234") {
-						userID @User_delete
-					}
-				}`
+                    deleteUser(id: "1234") {
+                        userID @User_delete
+                    }
+                }`
 			),
 			mockCollectedDoc(
 				`query TestQuery {
-					users(stringValue: "foo") @list(name: "All_Users") {
-						firstName
-					}
-				}`
+                    users(stringValue: "foo") @list(name: "All_Users") {
+                        firstName
+                    }
+                }`
 			),
 		]
 
@@ -888,56 +900,57 @@ describe('mutation artifacts', function () {
 		}).program
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "A",
-		    kind: "HoudiniMutation",
+        module.exports = {
+            name: "A",
+            kind: "HoudiniMutation",
+            hash: "b9e1e926be309c06c868dc2472c082b6829f93ae55e000317a1066378590a85d",
 
-		    raw: \`mutation A {
-		  deleteUser(id: "1234") {
-		    userID
-		  }
-		}
-		\`,
+            raw: \`mutation A {
+          deleteUser(id: "1234") {
+            userID
+          }
+        }
+        \`,
 
-		    rootType: "Mutation",
+            rootType: "Mutation",
 
-		    selection: {
-		        "deleteUser": {
-		            "type": "DeleteUserOutput",
-		            "keyRaw": "deleteUser(id: \\"1234\\")",
+            selection: {
+                "deleteUser": {
+                    "type": "DeleteUserOutput",
+                    "keyRaw": "deleteUser(id: \\"1234\\")",
 
-		            "fields": {
-		                "userID": {
-		                    "type": "ID",
-		                    "keyRaw": "userID",
+                    "fields": {
+                        "userID": {
+                            "type": "ID",
+                            "keyRaw": "userID",
 
-		                    "operations": [{
-		                        "action": "delete",
-		                        "type": "User"
-		                    }]
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                            "operations": [{
+                                "action": "delete",
+                                "type": "User"
+                            }]
+                        }
+                    }
+                }
+            }
+        };
+    `)
 	})
 
 	test('delete operation with condition', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
 				`mutation A {
-					deleteUser(id: "1234") {
-						userID @User_delete @when(argument: "stringValue", value: "foo")
-					}
-				}`
+                    deleteUser(id: "1234") {
+                        userID @User_delete @when(argument: "stringValue", value: "foo")
+                    }
+                }`
 			),
 			mockCollectedDoc(
 				`query TestQuery {
-					users(stringValue: "foo") @list(name: "All_Users") {
-						firstName
-					}
-				}`
+                    users(stringValue: "foo") @list(name: "All_Users") {
+                        firstName
+                    }
+                }`
 			),
 		]
 
@@ -956,64 +969,65 @@ describe('mutation artifacts', function () {
 		}).program
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "A",
-		    kind: "HoudiniMutation",
+        module.exports = {
+            name: "A",
+            kind: "HoudiniMutation",
+            hash: "b9e1e926be309c06c868dc2472c082b6829f93ae55e000317a1066378590a85d",
 
-		    raw: \`mutation A {
-		  deleteUser(id: "1234") {
-		    userID
-		  }
-		}
-		\`,
+            raw: \`mutation A {
+          deleteUser(id: "1234") {
+            userID
+          }
+        }
+        \`,
 
-		    rootType: "Mutation",
+            rootType: "Mutation",
 
-		    selection: {
-		        "deleteUser": {
-		            "type": "DeleteUserOutput",
-		            "keyRaw": "deleteUser(id: \\"1234\\")",
+            selection: {
+                "deleteUser": {
+                    "type": "DeleteUserOutput",
+                    "keyRaw": "deleteUser(id: \\"1234\\")",
 
-		            "fields": {
-		                "userID": {
-		                    "type": "ID",
-		                    "keyRaw": "userID",
+                    "fields": {
+                        "userID": {
+                            "type": "ID",
+                            "keyRaw": "userID",
 
-		                    "operations": [{
-		                        "action": "delete",
-		                        "type": "User",
+                            "operations": [{
+                                "action": "delete",
+                                "type": "User",
 
-		                        "when": {
-		                            "must": {
-		                                "stringValue": "foo"
-		                            }
-		                        }
-		                    }]
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                                "when": {
+                                    "must": {
+                                        "stringValue": "foo"
+                                    }
+                                }
+                            }]
+                        }
+                    }
+                }
+            }
+        };
+    `)
 	})
 
 	test('parentID - prepend', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
 				`mutation A {
-					addFriend {
-						friend {
-							...All_Users_insert @prepend(parentID: "1234")
-						}
-					}
-				}`
+                    addFriend {
+                        friend {
+                            ...All_Users_insert @prepend(parentID: "1234")
+                        }
+                    }
+                }`
 			),
 			mockCollectedDoc(
 				`query TestQuery {
-					users(stringValue: "foo") @list(name: "All_Users") {
-						firstName
-					}
-				}`
+                    users(stringValue: "foo") @list(name: "All_Users") {
+                        firstName
+                    }
+                }`
 			),
 		]
 
@@ -1032,84 +1046,85 @@ describe('mutation artifacts', function () {
 		}).program
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "A",
-		    kind: "HoudiniMutation",
+        module.exports = {
+            name: "A",
+            kind: "HoudiniMutation",
+            hash: "7cc5c23ffd19603e2c7c727d1ac2726d4d87ee6b0470ced7d28c7f0ed88a05c2",
 
-		    raw: \`mutation A {
-		  addFriend {
-		    friend {
-		      ...All_Users_insert
-		      id
-		    }
-		  }
-		}
+            raw: \`mutation A {
+          addFriend {
+            friend {
+              ...All_Users_insert
+              id
+            }
+          }
+        }
 
-		fragment All_Users_insert on User {
-		  firstName
-		  id
-		}
-		\`,
+        fragment All_Users_insert on User {
+          firstName
+          id
+        }
+        \`,
 
-		    rootType: "Mutation",
+            rootType: "Mutation",
 
-		    selection: {
-		        "addFriend": {
-		            "type": "AddFriendOutput",
-		            "keyRaw": "addFriend",
+            selection: {
+                "addFriend": {
+                    "type": "AddFriendOutput",
+                    "keyRaw": "addFriend",
 
-		            "fields": {
-		                "friend": {
-		                    "type": "User",
-		                    "keyRaw": "friend",
+                    "fields": {
+                        "friend": {
+                            "type": "User",
+                            "keyRaw": "friend",
 
-		                    "fields": {
-		                        "firstName": {
-		                            "type": "String",
-		                            "keyRaw": "firstName"
-		                        },
+                            "fields": {
+                                "firstName": {
+                                    "type": "String",
+                                    "keyRaw": "firstName"
+                                },
 
-		                        "id": {
-		                            "type": "ID",
-		                            "keyRaw": "id"
-		                        }
-		                    },
+                                "id": {
+                                    "type": "ID",
+                                    "keyRaw": "id"
+                                }
+                            },
 
-		                    "operations": [{
-		                        "action": "insert",
-		                        "list": "All_Users",
-		                        "position": "first",
+                            "operations": [{
+                                "action": "insert",
+                                "list": "All_Users",
+                                "position": "first",
 
-		                        "parentID": {
-		                            "kind": "String",
-		                            "value": "1234"
-		                        }
-		                    }]
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                                "parentID": {
+                                    "kind": "String",
+                                    "value": "1234"
+                                }
+                            }]
+                        }
+                    }
+                }
+            }
+        };
+    `)
 	})
 
 	test('parentID - append', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
 				`mutation A {
-					addFriend {
-						friend {
-							...All_Users_insert @append(parentID: "1234")
-						}
-					}
-				}`
+                    addFriend {
+                        friend {
+                            ...All_Users_insert @append(parentID: "1234")
+                        }
+                    }
+                }`
 			),
 			mockCollectedDoc(
 				`query TestQuery {
-					users(stringValue: "foo") @list(name: "All_Users") {
-						firstName
-					}
-				}`
+                    users(stringValue: "foo") @list(name: "All_Users") {
+                        firstName
+                    }
+                }`
 			),
 		]
 
@@ -1128,84 +1143,85 @@ describe('mutation artifacts', function () {
 		}).program
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "A",
-		    kind: "HoudiniMutation",
+        module.exports = {
+            name: "A",
+            kind: "HoudiniMutation",
+            hash: "7cc5c23ffd19603e2c7c727d1ac2726d4d87ee6b0470ced7d28c7f0ed88a05c2",
 
-		    raw: \`mutation A {
-		  addFriend {
-		    friend {
-		      ...All_Users_insert
-		      id
-		    }
-		  }
-		}
+            raw: \`mutation A {
+          addFriend {
+            friend {
+              ...All_Users_insert
+              id
+            }
+          }
+        }
 
-		fragment All_Users_insert on User {
-		  firstName
-		  id
-		}
-		\`,
+        fragment All_Users_insert on User {
+          firstName
+          id
+        }
+        \`,
 
-		    rootType: "Mutation",
+            rootType: "Mutation",
 
-		    selection: {
-		        "addFriend": {
-		            "type": "AddFriendOutput",
-		            "keyRaw": "addFriend",
+            selection: {
+                "addFriend": {
+                    "type": "AddFriendOutput",
+                    "keyRaw": "addFriend",
 
-		            "fields": {
-		                "friend": {
-		                    "type": "User",
-		                    "keyRaw": "friend",
+                    "fields": {
+                        "friend": {
+                            "type": "User",
+                            "keyRaw": "friend",
 
-		                    "fields": {
-		                        "firstName": {
-		                            "type": "String",
-		                            "keyRaw": "firstName"
-		                        },
+                            "fields": {
+                                "firstName": {
+                                    "type": "String",
+                                    "keyRaw": "firstName"
+                                },
 
-		                        "id": {
-		                            "type": "ID",
-		                            "keyRaw": "id"
-		                        }
-		                    },
+                                "id": {
+                                    "type": "ID",
+                                    "keyRaw": "id"
+                                }
+                            },
 
-		                    "operations": [{
-		                        "action": "insert",
-		                        "list": "All_Users",
-		                        "position": "last",
+                            "operations": [{
+                                "action": "insert",
+                                "list": "All_Users",
+                                "position": "last",
 
-		                        "parentID": {
-		                            "kind": "String",
-		                            "value": "1234"
-		                        }
-		                    }]
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                                "parentID": {
+                                    "kind": "String",
+                                    "value": "1234"
+                                }
+                            }]
+                        }
+                    }
+                }
+            }
+        };
+    `)
 	})
 
 	test('parentID - parentID directive', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
 				`mutation A {
-					addFriend {
-						friend {
-							...All_Users_insert @parentID(value: "1234")
-						}
-					}
-				}`
+                    addFriend {
+                        friend {
+                            ...All_Users_insert @parentID(value: "1234")
+                        }
+                    }
+                }`
 			),
 			mockCollectedDoc(
 				`query TestQuery {
-					users(stringValue: "foo") @list(name: "All_Users") {
-						firstName
-					}
-				}`
+                    users(stringValue: "foo") @list(name: "All_Users") {
+                        firstName
+                    }
+                }`
 			),
 		]
 
@@ -1224,84 +1240,85 @@ describe('mutation artifacts', function () {
 		}).program
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "A",
-		    kind: "HoudiniMutation",
+        module.exports = {
+            name: "A",
+            kind: "HoudiniMutation",
+            hash: "7cc5c23ffd19603e2c7c727d1ac2726d4d87ee6b0470ced7d28c7f0ed88a05c2",
 
-		    raw: \`mutation A {
-		  addFriend {
-		    friend {
-		      ...All_Users_insert
-		      id
-		    }
-		  }
-		}
+            raw: \`mutation A {
+          addFriend {
+            friend {
+              ...All_Users_insert
+              id
+            }
+          }
+        }
 
-		fragment All_Users_insert on User {
-		  firstName
-		  id
-		}
-		\`,
+        fragment All_Users_insert on User {
+          firstName
+          id
+        }
+        \`,
 
-		    rootType: "Mutation",
+            rootType: "Mutation",
 
-		    selection: {
-		        "addFriend": {
-		            "type": "AddFriendOutput",
-		            "keyRaw": "addFriend",
+            selection: {
+                "addFriend": {
+                    "type": "AddFriendOutput",
+                    "keyRaw": "addFriend",
 
-		            "fields": {
-		                "friend": {
-		                    "type": "User",
-		                    "keyRaw": "friend",
+                    "fields": {
+                        "friend": {
+                            "type": "User",
+                            "keyRaw": "friend",
 
-		                    "fields": {
-		                        "firstName": {
-		                            "type": "String",
-		                            "keyRaw": "firstName"
-		                        },
+                            "fields": {
+                                "firstName": {
+                                    "type": "String",
+                                    "keyRaw": "firstName"
+                                },
 
-		                        "id": {
-		                            "type": "ID",
-		                            "keyRaw": "id"
-		                        }
-		                    },
+                                "id": {
+                                    "type": "ID",
+                                    "keyRaw": "id"
+                                }
+                            },
 
-		                    "operations": [{
-		                        "action": "insert",
-		                        "list": "All_Users",
-		                        "position": "last",
+                            "operations": [{
+                                "action": "insert",
+                                "list": "All_Users",
+                                "position": "last",
 
-		                        "parentID": {
-		                            "kind": "String",
-		                            "value": "1234"
-		                        }
-		                    }]
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                                "parentID": {
+                                    "kind": "String",
+                                    "value": "1234"
+                                }
+                            }]
+                        }
+                    }
+                }
+            }
+        };
+    `)
 	})
 
 	test('must - prepend', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
 				`mutation A {
-					addFriend {
-						friend {
-							...All_Users_insert @prepend(when: { argument: "stringValue", value: "foo" })
-						}
-					}
-				}`
+                    addFriend {
+                        friend {
+                            ...All_Users_insert @prepend(when: { argument: "stringValue", value: "foo" })
+                        }
+                    }
+                }`
 			),
 			mockCollectedDoc(
 				`query TestQuery {
-					users(stringValue: "foo") @list(name: "All_Users") {
-						firstName
-					}
-				}`
+                    users(stringValue: "foo") @list(name: "All_Users") {
+                        firstName
+                    }
+                }`
 			),
 		]
 
@@ -1320,85 +1337,86 @@ describe('mutation artifacts', function () {
 		}).program
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "A",
-		    kind: "HoudiniMutation",
+        module.exports = {
+            name: "A",
+            kind: "HoudiniMutation",
+            hash: "7cc5c23ffd19603e2c7c727d1ac2726d4d87ee6b0470ced7d28c7f0ed88a05c2",
 
-		    raw: \`mutation A {
-		  addFriend {
-		    friend {
-		      ...All_Users_insert
-		      id
-		    }
-		  }
-		}
+            raw: \`mutation A {
+          addFriend {
+            friend {
+              ...All_Users_insert
+              id
+            }
+          }
+        }
 
-		fragment All_Users_insert on User {
-		  firstName
-		  id
-		}
-		\`,
+        fragment All_Users_insert on User {
+          firstName
+          id
+        }
+        \`,
 
-		    rootType: "Mutation",
+            rootType: "Mutation",
 
-		    selection: {
-		        "addFriend": {
-		            "type": "AddFriendOutput",
-		            "keyRaw": "addFriend",
+            selection: {
+                "addFriend": {
+                    "type": "AddFriendOutput",
+                    "keyRaw": "addFriend",
 
-		            "fields": {
-		                "friend": {
-		                    "type": "User",
-		                    "keyRaw": "friend",
+                    "fields": {
+                        "friend": {
+                            "type": "User",
+                            "keyRaw": "friend",
 
-		                    "fields": {
-		                        "firstName": {
-		                            "type": "String",
-		                            "keyRaw": "firstName"
-		                        },
+                            "fields": {
+                                "firstName": {
+                                    "type": "String",
+                                    "keyRaw": "firstName"
+                                },
 
-		                        "id": {
-		                            "type": "ID",
-		                            "keyRaw": "id"
-		                        }
-		                    },
+                                "id": {
+                                    "type": "ID",
+                                    "keyRaw": "id"
+                                }
+                            },
 
-		                    "operations": [{
-		                        "action": "insert",
-		                        "list": "All_Users",
-		                        "position": "first",
+                            "operations": [{
+                                "action": "insert",
+                                "list": "All_Users",
+                                "position": "first",
 
-		                        "when": {
-		                            "must": {
-		                                "stringValue": "foo"
-		                            }
-		                        }
-		                    }]
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                                "when": {
+                                    "must": {
+                                        "stringValue": "foo"
+                                    }
+                                }
+                            }]
+                        }
+                    }
+                }
+            }
+        };
+    `)
 	})
 
 	test('must - append', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
 				`mutation A {
-					addFriend {
-						friend {
-							...All_Users_insert @append(when: { argument: "stringValue", value: "true" })
-						}
-					}
-				}`
+                    addFriend {
+                        friend {
+                            ...All_Users_insert @append(when: { argument: "stringValue", value: "true" })
+                        }
+                    }
+                }`
 			),
 			mockCollectedDoc(
 				`query TestQuery {
-					users(stringValue: "foo") @list(name: "All_Users") {
-						firstName
-					}
-				}`
+                    users(stringValue: "foo") @list(name: "All_Users") {
+                        firstName
+                    }
+                }`
 			),
 		]
 
@@ -1417,85 +1435,86 @@ describe('mutation artifacts', function () {
 		}).program
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "A",
-		    kind: "HoudiniMutation",
+        module.exports = {
+            name: "A",
+            kind: "HoudiniMutation",
+            hash: "7cc5c23ffd19603e2c7c727d1ac2726d4d87ee6b0470ced7d28c7f0ed88a05c2",
 
-		    raw: \`mutation A {
-		  addFriend {
-		    friend {
-		      ...All_Users_insert
-		      id
-		    }
-		  }
-		}
+            raw: \`mutation A {
+          addFriend {
+            friend {
+              ...All_Users_insert
+              id
+            }
+          }
+        }
 
-		fragment All_Users_insert on User {
-		  firstName
-		  id
-		}
-		\`,
+        fragment All_Users_insert on User {
+          firstName
+          id
+        }
+        \`,
 
-		    rootType: "Mutation",
+            rootType: "Mutation",
 
-		    selection: {
-		        "addFriend": {
-		            "type": "AddFriendOutput",
-		            "keyRaw": "addFriend",
+            selection: {
+                "addFriend": {
+                    "type": "AddFriendOutput",
+                    "keyRaw": "addFriend",
 
-		            "fields": {
-		                "friend": {
-		                    "type": "User",
-		                    "keyRaw": "friend",
+                    "fields": {
+                        "friend": {
+                            "type": "User",
+                            "keyRaw": "friend",
 
-		                    "fields": {
-		                        "firstName": {
-		                            "type": "String",
-		                            "keyRaw": "firstName"
-		                        },
+                            "fields": {
+                                "firstName": {
+                                    "type": "String",
+                                    "keyRaw": "firstName"
+                                },
 
-		                        "id": {
-		                            "type": "ID",
-		                            "keyRaw": "id"
-		                        }
-		                    },
+                                "id": {
+                                    "type": "ID",
+                                    "keyRaw": "id"
+                                }
+                            },
 
-		                    "operations": [{
-		                        "action": "insert",
-		                        "list": "All_Users",
-		                        "position": "last",
+                            "operations": [{
+                                "action": "insert",
+                                "list": "All_Users",
+                                "position": "last",
 
-		                        "when": {
-		                            "must": {
-		                                "stringValue": "true"
-		                            }
-		                        }
-		                    }]
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                                "when": {
+                                    "must": {
+                                        "stringValue": "true"
+                                    }
+                                }
+                            }]
+                        }
+                    }
+                }
+            }
+        };
+    `)
 	})
 
 	test('must - directive', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
 				`mutation A {
-					addFriend {
-						friend {
-							...All_Users_insert @when(argument: "stringValue", value: "true")
-						}
-					}
-				}`
+                    addFriend {
+                        friend {
+                            ...All_Users_insert @when(argument: "stringValue", value: "true")
+                        }
+                    }
+                }`
 			),
 			mockCollectedDoc(
 				`query TestQuery {
-					users(stringValue: "foo") @list(name: "All_Users") {
-						firstName
-					}
-				}`
+                    users(stringValue: "foo") @list(name: "All_Users") {
+                        firstName
+                    }
+                }`
 			),
 		]
 
@@ -1514,85 +1533,86 @@ describe('mutation artifacts', function () {
 		}).program
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "A",
-		    kind: "HoudiniMutation",
+        module.exports = {
+            name: "A",
+            kind: "HoudiniMutation",
+            hash: "7cc5c23ffd19603e2c7c727d1ac2726d4d87ee6b0470ced7d28c7f0ed88a05c2",
 
-		    raw: \`mutation A {
-		  addFriend {
-		    friend {
-		      ...All_Users_insert
-		      id
-		    }
-		  }
-		}
+            raw: \`mutation A {
+          addFriend {
+            friend {
+              ...All_Users_insert
+              id
+            }
+          }
+        }
 
-		fragment All_Users_insert on User {
-		  firstName
-		  id
-		}
-		\`,
+        fragment All_Users_insert on User {
+          firstName
+          id
+        }
+        \`,
 
-		    rootType: "Mutation",
+            rootType: "Mutation",
 
-		    selection: {
-		        "addFriend": {
-		            "type": "AddFriendOutput",
-		            "keyRaw": "addFriend",
+            selection: {
+                "addFriend": {
+                    "type": "AddFriendOutput",
+                    "keyRaw": "addFriend",
 
-		            "fields": {
-		                "friend": {
-		                    "type": "User",
-		                    "keyRaw": "friend",
+                    "fields": {
+                        "friend": {
+                            "type": "User",
+                            "keyRaw": "friend",
 
-		                    "fields": {
-		                        "firstName": {
-		                            "type": "String",
-		                            "keyRaw": "firstName"
-		                        },
+                            "fields": {
+                                "firstName": {
+                                    "type": "String",
+                                    "keyRaw": "firstName"
+                                },
 
-		                        "id": {
-		                            "type": "ID",
-		                            "keyRaw": "id"
-		                        }
-		                    },
+                                "id": {
+                                    "type": "ID",
+                                    "keyRaw": "id"
+                                }
+                            },
 
-		                    "operations": [{
-		                        "action": "insert",
-		                        "list": "All_Users",
-		                        "position": "last",
+                            "operations": [{
+                                "action": "insert",
+                                "list": "All_Users",
+                                "position": "last",
 
-		                        "when": {
-		                            "must": {
-		                                "stringValue": "true"
-		                            }
-		                        }
-		                    }]
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                                "when": {
+                                    "must": {
+                                        "stringValue": "true"
+                                    }
+                                }
+                            }]
+                        }
+                    }
+                }
+            }
+        };
+    `)
 	})
 
 	test('must_not - prepend', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
 				`mutation A {
-					addFriend {
-						friend {
-							...All_Users_insert @prepend(when_not: { argument: "stringValue", value: "true" })
-						}
-					}
-				}`
+                    addFriend {
+                        friend {
+                            ...All_Users_insert @prepend(when_not: { argument: "stringValue", value: "true" })
+                        }
+                    }
+                }`
 			),
 			mockCollectedDoc(
 				`query TestQuery {
-					users(stringValue: "foo") @list(name: "All_Users") {
-						firstName
-					}
-				}`
+                    users(stringValue: "foo") @list(name: "All_Users") {
+                        firstName
+                    }
+                }`
 			),
 		]
 
@@ -1611,85 +1631,86 @@ describe('mutation artifacts', function () {
 		}).program
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "A",
-		    kind: "HoudiniMutation",
+        module.exports = {
+            name: "A",
+            kind: "HoudiniMutation",
+            hash: "7cc5c23ffd19603e2c7c727d1ac2726d4d87ee6b0470ced7d28c7f0ed88a05c2",
 
-		    raw: \`mutation A {
-		  addFriend {
-		    friend {
-		      ...All_Users_insert
-		      id
-		    }
-		  }
-		}
+            raw: \`mutation A {
+          addFriend {
+            friend {
+              ...All_Users_insert
+              id
+            }
+          }
+        }
 
-		fragment All_Users_insert on User {
-		  firstName
-		  id
-		}
-		\`,
+        fragment All_Users_insert on User {
+          firstName
+          id
+        }
+        \`,
 
-		    rootType: "Mutation",
+            rootType: "Mutation",
 
-		    selection: {
-		        "addFriend": {
-		            "type": "AddFriendOutput",
-		            "keyRaw": "addFriend",
+            selection: {
+                "addFriend": {
+                    "type": "AddFriendOutput",
+                    "keyRaw": "addFriend",
 
-		            "fields": {
-		                "friend": {
-		                    "type": "User",
-		                    "keyRaw": "friend",
+                    "fields": {
+                        "friend": {
+                            "type": "User",
+                            "keyRaw": "friend",
 
-		                    "fields": {
-		                        "firstName": {
-		                            "type": "String",
-		                            "keyRaw": "firstName"
-		                        },
+                            "fields": {
+                                "firstName": {
+                                    "type": "String",
+                                    "keyRaw": "firstName"
+                                },
 
-		                        "id": {
-		                            "type": "ID",
-		                            "keyRaw": "id"
-		                        }
-		                    },
+                                "id": {
+                                    "type": "ID",
+                                    "keyRaw": "id"
+                                }
+                            },
 
-		                    "operations": [{
-		                        "action": "insert",
-		                        "list": "All_Users",
-		                        "position": "first",
+                            "operations": [{
+                                "action": "insert",
+                                "list": "All_Users",
+                                "position": "first",
 
-		                        "when": {
-		                            "must_not": {
-		                                "stringValue": "true"
-		                            }
-		                        }
-		                    }]
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                                "when": {
+                                    "must_not": {
+                                        "stringValue": "true"
+                                    }
+                                }
+                            }]
+                        }
+                    }
+                }
+            }
+        };
+    `)
 	})
 
 	test('must_not - append', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
 				`mutation A {
-					addFriend {
-						friend {
-							...All_Users_insert @append(when_not: { argument: "stringValue", value: "true" })
-						}
-					}
-				}`
+                    addFriend {
+                        friend {
+                            ...All_Users_insert @append(when_not: { argument: "stringValue", value: "true" })
+                        }
+                    }
+                }`
 			),
 			mockCollectedDoc(
 				`query TestQuery {
-					users(stringValue: "foo") @list(name: "All_Users") {
-						firstName
-					}
-				}`
+                    users(stringValue: "foo") @list(name: "All_Users") {
+                        firstName
+                    }
+                }`
 			),
 		]
 
@@ -1708,90 +1729,91 @@ describe('mutation artifacts', function () {
 		}).program
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "A",
-		    kind: "HoudiniMutation",
+        module.exports = {
+            name: "A",
+            kind: "HoudiniMutation",
+            hash: "7cc5c23ffd19603e2c7c727d1ac2726d4d87ee6b0470ced7d28c7f0ed88a05c2",
 
-		    raw: \`mutation A {
-		  addFriend {
-		    friend {
-		      ...All_Users_insert
-		      id
-		    }
-		  }
-		}
+            raw: \`mutation A {
+          addFriend {
+            friend {
+              ...All_Users_insert
+              id
+            }
+          }
+        }
 
-		fragment All_Users_insert on User {
-		  firstName
-		  id
-		}
-		\`,
+        fragment All_Users_insert on User {
+          firstName
+          id
+        }
+        \`,
 
-		    rootType: "Mutation",
+            rootType: "Mutation",
 
-		    selection: {
-		        "addFriend": {
-		            "type": "AddFriendOutput",
-		            "keyRaw": "addFriend",
+            selection: {
+                "addFriend": {
+                    "type": "AddFriendOutput",
+                    "keyRaw": "addFriend",
 
-		            "fields": {
-		                "friend": {
-		                    "type": "User",
-		                    "keyRaw": "friend",
+                    "fields": {
+                        "friend": {
+                            "type": "User",
+                            "keyRaw": "friend",
 
-		                    "fields": {
-		                        "firstName": {
-		                            "type": "String",
-		                            "keyRaw": "firstName"
-		                        },
+                            "fields": {
+                                "firstName": {
+                                    "type": "String",
+                                    "keyRaw": "firstName"
+                                },
 
-		                        "id": {
-		                            "type": "ID",
-		                            "keyRaw": "id"
-		                        }
-		                    },
+                                "id": {
+                                    "type": "ID",
+                                    "keyRaw": "id"
+                                }
+                            },
 
-		                    "operations": [{
-		                        "action": "insert",
-		                        "list": "All_Users",
-		                        "position": "last",
+                            "operations": [{
+                                "action": "insert",
+                                "list": "All_Users",
+                                "position": "last",
 
-		                        "when": {
-		                            "must_not": {
-		                                "stringValue": "true"
-		                            }
-		                        }
-		                    }]
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                                "when": {
+                                    "must_not": {
+                                        "stringValue": "true"
+                                    }
+                                }
+                            }]
+                        }
+                    }
+                }
+            }
+        };
+    `)
 	})
 
 	test('list filters', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
 				`mutation A {
-					addFriend {
-						friend {
-							...All_Users_insert @when_not(argument: "boolValue", value: "true")
-						}
-					}
-				}`
+                    addFriend {
+                        friend {
+                            ...All_Users_insert @when_not(argument: "boolValue", value: "true")
+                        }
+                    }
+                }`
 			),
 			mockCollectedDoc(
 				`query TestQuery($value: String!) {
-					users(
-						stringValue: $value,
-						boolValue: true,
-						floatValue: 1.2,
-						intValue: 1,
-					) @list(name: "All_Users") {
-						firstName
-					}
-				}`
+                    users(
+                        stringValue: $value,
+                        boolValue: true,
+                        floatValue: 1.2,
+                        intValue: 1,
+                    ) @list(name: "All_Users") {
+                        firstName
+                    }
+                }`
 			),
 		]
 
@@ -1810,91 +1832,92 @@ describe('mutation artifacts', function () {
 		}).program
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "TestQuery",
-		    kind: "HoudiniQuery",
+        module.exports = {
+            name: "TestQuery",
+            kind: "HoudiniQuery",
+            hash: "d773bead4120baa620dc05347fba277faaa5bb555e10943507a393eaa3399c52",
 
-		    raw: \`query TestQuery($value: String!) {
-		  users(stringValue: $value, boolValue: true, floatValue: 1.2, intValue: 1) {
-		    firstName
-		    id
-		  }
-		}
-		\`,
+            raw: \`query TestQuery($value: String!) {
+          users(stringValue: $value, boolValue: true, floatValue: 1.2, intValue: 1) {
+            firstName
+            id
+          }
+        }
+        \`,
 
-		    rootType: "Query",
+            rootType: "Query",
 
-		    selection: {
-		        "users": {
-		            "type": "User",
-		            "keyRaw": "users(stringValue: $value, boolValue: true, floatValue: 1.2, intValue: 1)",
+            selection: {
+                "users": {
+                    "type": "User",
+                    "keyRaw": "users(stringValue: $value, boolValue: true, floatValue: 1.2, intValue: 1)",
 
-		            "fields": {
-		                "firstName": {
-		                    "type": "String",
-		                    "keyRaw": "firstName"
-		                },
+                    "fields": {
+                        "firstName": {
+                            "type": "String",
+                            "keyRaw": "firstName"
+                        },
 
-		                "id": {
-		                    "type": "ID",
-		                    "keyRaw": "id"
-		                }
-		            },
+                        "id": {
+                            "type": "ID",
+                            "keyRaw": "id"
+                        }
+                    },
 
-		            "list": "All_Users",
+                    "list": "All_Users",
 
-		            "filters": {
-		                "stringValue": {
-		                    "kind": "Variable",
-		                    "value": "value"
-		                },
+                    "filters": {
+                        "stringValue": {
+                            "kind": "Variable",
+                            "value": "value"
+                        },
 
-		                "boolValue": {
-		                    "kind": "Boolean",
-		                    "value": true
-		                },
+                        "boolValue": {
+                            "kind": "Boolean",
+                            "value": true
+                        },
 
-		                "floatValue": {
-		                    "kind": "Float",
-		                    "value": 1.2
-		                },
+                        "floatValue": {
+                            "kind": "Float",
+                            "value": 1.2
+                        },
 
-		                "intValue": {
-		                    "kind": "Int",
-		                    "value": 1
-		                }
-		            }
-		        }
-		    },
+                        "intValue": {
+                            "kind": "Int",
+                            "value": 1
+                        }
+                    }
+                }
+            },
 
-		    input: {
-		        "fields": {
-		            "value": "String"
-		        },
+            input: {
+                "fields": {
+                    "value": "String"
+                },
 
-		        "types": {}
-		    }
-		};
-	`)
+                "types": {}
+            }
+        };
+    `)
 	})
 
 	test('must_not - directive', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
 				`mutation A {
-					addFriend {
-						friend {
-							...All_Users_insert @when_not(argument: "boolValue", value: "true")
-						}
-					}
-				}`
+                    addFriend {
+                        friend {
+                            ...All_Users_insert @when_not(argument: "boolValue", value: "true")
+                        }
+                    }
+                }`
 			),
 			mockCollectedDoc(
 				`query TestQuery {
-					users(stringValue: "foo", boolValue:true) @list(name: "All_Users") {
-						firstName
-					}
-				}`
+                    users(stringValue: "foo", boolValue:true) @list(name: "All_Users") {
+                        firstName
+                    }
+                }`
 			),
 		]
 
@@ -1913,85 +1936,86 @@ describe('mutation artifacts', function () {
 		}).program
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "A",
-		    kind: "HoudiniMutation",
+        module.exports = {
+            name: "A",
+            kind: "HoudiniMutation",
+            hash: "7cc5c23ffd19603e2c7c727d1ac2726d4d87ee6b0470ced7d28c7f0ed88a05c2",
 
-		    raw: \`mutation A {
-		  addFriend {
-		    friend {
-		      ...All_Users_insert
-		      id
-		    }
-		  }
-		}
+            raw: \`mutation A {
+          addFriend {
+            friend {
+              ...All_Users_insert
+              id
+            }
+          }
+        }
 
-		fragment All_Users_insert on User {
-		  firstName
-		  id
-		}
-		\`,
+        fragment All_Users_insert on User {
+          firstName
+          id
+        }
+        \`,
 
-		    rootType: "Mutation",
+            rootType: "Mutation",
 
-		    selection: {
-		        "addFriend": {
-		            "type": "AddFriendOutput",
-		            "keyRaw": "addFriend",
+            selection: {
+                "addFriend": {
+                    "type": "AddFriendOutput",
+                    "keyRaw": "addFriend",
 
-		            "fields": {
-		                "friend": {
-		                    "type": "User",
-		                    "keyRaw": "friend",
+                    "fields": {
+                        "friend": {
+                            "type": "User",
+                            "keyRaw": "friend",
 
-		                    "fields": {
-		                        "firstName": {
-		                            "type": "String",
-		                            "keyRaw": "firstName"
-		                        },
+                            "fields": {
+                                "firstName": {
+                                    "type": "String",
+                                    "keyRaw": "firstName"
+                                },
 
-		                        "id": {
-		                            "type": "ID",
-		                            "keyRaw": "id"
-		                        }
-		                    },
+                                "id": {
+                                    "type": "ID",
+                                    "keyRaw": "id"
+                                }
+                            },
 
-		                    "operations": [{
-		                        "action": "insert",
-		                        "list": "All_Users",
-		                        "position": "last",
+                            "operations": [{
+                                "action": "insert",
+                                "list": "All_Users",
+                                "position": "last",
 
-		                        "when": {
-		                            "must_not": {
-		                                "boolValue": true
-		                            }
-		                        }
-		                    }]
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                                "when": {
+                                    "must_not": {
+                                        "boolValue": true
+                                    }
+                                }
+                            }]
+                        }
+                    }
+                }
+            }
+        };
+    `)
 	})
 
 	test('tracks list name', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
 				`mutation A {
-					addFriend {
-						friend {
-							...All_Users_insert @prepend(parentID: "1234")
-						}
-					}
-				}`
+                    addFriend {
+                        friend {
+                            ...All_Users_insert @prepend(parentID: "1234")
+                        }
+                    }
+                }`
 			),
 			mockCollectedDoc(
 				`query TestQuery {
-					users(stringValue: "foo") @list(name: "All_Users") {
-						firstName
-					}
-				}`
+                    users(stringValue: "foo") @list(name: "All_Users") {
+                        firstName
+                    }
+                }`
 			),
 		]
 
@@ -2010,64 +2034,65 @@ describe('mutation artifacts', function () {
 		}).program
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "TestQuery",
-		    kind: "HoudiniQuery",
+        module.exports = {
+            name: "TestQuery",
+            kind: "HoudiniQuery",
+            hash: "2997353b3d1f04e02b9d211bb4f4069b63f8536b7f1eb686fc74fd8b3dab8dbd",
 
-		    raw: \`query TestQuery {
-		  users(stringValue: "foo") {
-		    firstName
-		    id
-		  }
-		}
-		\`,
+            raw: \`query TestQuery {
+          users(stringValue: "foo") {
+            firstName
+            id
+          }
+        }
+        \`,
 
-		    rootType: "Query",
+            rootType: "Query",
 
-		    selection: {
-		        "users": {
-		            "type": "User",
-		            "keyRaw": "users(stringValue: \\"foo\\")",
+            selection: {
+                "users": {
+                    "type": "User",
+                    "keyRaw": "users(stringValue: \\"foo\\")",
 
-		            "fields": {
-		                "firstName": {
-		                    "type": "String",
-		                    "keyRaw": "firstName"
-		                },
+                    "fields": {
+                        "firstName": {
+                            "type": "String",
+                            "keyRaw": "firstName"
+                        },
 
-		                "id": {
-		                    "type": "ID",
-		                    "keyRaw": "id"
-		                }
-		            },
+                        "id": {
+                            "type": "ID",
+                            "keyRaw": "id"
+                        }
+                    },
 
-		            "list": "All_Users",
+                    "list": "All_Users",
 
-		            "filters": {
-		                "stringValue": {
-		                    "kind": "String",
-		                    "value": "foo"
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                    "filters": {
+                        "stringValue": {
+                            "kind": "String",
+                            "value": "foo"
+                        }
+                    }
+                }
+            }
+        };
+    `)
 	})
 
 	test('field args', async function () {
 		const mutationDocs = [
 			mockCollectedDoc(
 				`query TestQuery($value: String!) {
-					users(
-						stringValue: $value,
-						boolValue: true,
-						floatValue: 1.2,
-						intValue: 1,
-					) @list(name: "All_Users") {
-						firstName
-					}
-				}`
+                    users(
+                        stringValue: $value,
+                        boolValue: true,
+                        floatValue: 1.2,
+                        intValue: 1,
+                    ) @list(name: "All_Users") {
+                        firstName
+                    }
+                }`
 			),
 		]
 
@@ -2086,72 +2111,73 @@ describe('mutation artifacts', function () {
 		}).program
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "TestQuery",
-		    kind: "HoudiniQuery",
+        module.exports = {
+            name: "TestQuery",
+            kind: "HoudiniQuery",
+            hash: "d773bead4120baa620dc05347fba277faaa5bb555e10943507a393eaa3399c52",
 
-		    raw: \`query TestQuery($value: String!) {
-		  users(stringValue: $value, boolValue: true, floatValue: 1.2, intValue: 1) {
-		    firstName
-		    id
-		  }
-		}
-		\`,
+            raw: \`query TestQuery($value: String!) {
+          users(stringValue: $value, boolValue: true, floatValue: 1.2, intValue: 1) {
+            firstName
+            id
+          }
+        }
+        \`,
 
-		    rootType: "Query",
+            rootType: "Query",
 
-		    selection: {
-		        "users": {
-		            "type": "User",
-		            "keyRaw": "users(stringValue: $value, boolValue: true, floatValue: 1.2, intValue: 1)",
+            selection: {
+                "users": {
+                    "type": "User",
+                    "keyRaw": "users(stringValue: $value, boolValue: true, floatValue: 1.2, intValue: 1)",
 
-		            "fields": {
-		                "firstName": {
-		                    "type": "String",
-		                    "keyRaw": "firstName"
-		                },
+                    "fields": {
+                        "firstName": {
+                            "type": "String",
+                            "keyRaw": "firstName"
+                        },
 
-		                "id": {
-		                    "type": "ID",
-		                    "keyRaw": "id"
-		                }
-		            },
+                        "id": {
+                            "type": "ID",
+                            "keyRaw": "id"
+                        }
+                    },
 
-		            "list": "All_Users",
+                    "list": "All_Users",
 
-		            "filters": {
-		                "stringValue": {
-		                    "kind": "Variable",
-		                    "value": "value"
-		                },
+                    "filters": {
+                        "stringValue": {
+                            "kind": "Variable",
+                            "value": "value"
+                        },
 
-		                "boolValue": {
-		                    "kind": "Boolean",
-		                    "value": true
-		                },
+                        "boolValue": {
+                            "kind": "Boolean",
+                            "value": true
+                        },
 
-		                "floatValue": {
-		                    "kind": "Float",
-		                    "value": 1.2
-		                },
+                        "floatValue": {
+                            "kind": "Float",
+                            "value": 1.2
+                        },
 
-		                "intValue": {
-		                    "kind": "Int",
-		                    "value": 1
-		                }
-		            }
-		        }
-		    },
+                        "intValue": {
+                            "kind": "Int",
+                            "value": 1
+                        }
+                    }
+                }
+            },
 
-		    input: {
-		        "fields": {
-		            "value": "String"
-		        },
+            input: {
+                "fields": {
+                    "value": "String"
+                },
 
-		        "types": {}
-		    }
-		};
-	`)
+                "types": {}
+            }
+        };
+    `)
 	})
 
 	test('sveltekit', async function () {
@@ -2160,15 +2186,15 @@ describe('mutation artifacts', function () {
 		const mutationDocs = [
 			mockCollectedDoc(
 				`query TestQuery($value: String!) {
-					users(
-						stringValue: $value,
-						boolValue: true,
-						floatValue: 1.2,
-						intValue: 1,
-					) @list(name: "All_Users") {
-						firstName
-					}
-				}`
+                    users(
+                        stringValue: $value,
+                        boolValue: true,
+                        floatValue: 1.2,
+                        intValue: 1,
+                    ) @list(name: "All_Users") {
+                        firstName
+                    }
+                }`
 			),
 		]
 
@@ -2187,72 +2213,73 @@ describe('mutation artifacts', function () {
 		}).program
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
-		export default {
-		    name: "TestQuery",
-		    kind: "HoudiniQuery",
+        export default {
+            name: "TestQuery",
+            kind: "HoudiniQuery",
+            hash: "d773bead4120baa620dc05347fba277faaa5bb555e10943507a393eaa3399c52",
 
-		    raw: \`query TestQuery($value: String!) {
-		  users(stringValue: $value, boolValue: true, floatValue: 1.2, intValue: 1) {
-		    firstName
-		    id
-		  }
-		}
-		\`,
+            raw: \`query TestQuery($value: String!) {
+          users(stringValue: $value, boolValue: true, floatValue: 1.2, intValue: 1) {
+            firstName
+            id
+          }
+        }
+        \`,
 
-		    rootType: "Query",
+            rootType: "Query",
 
-		    selection: {
-		        "users": {
-		            "type": "User",
-		            "keyRaw": "users(stringValue: $value, boolValue: true, floatValue: 1.2, intValue: 1)",
+            selection: {
+                "users": {
+                    "type": "User",
+                    "keyRaw": "users(stringValue: $value, boolValue: true, floatValue: 1.2, intValue: 1)",
 
-		            "fields": {
-		                "firstName": {
-		                    "type": "String",
-		                    "keyRaw": "firstName"
-		                },
+                    "fields": {
+                        "firstName": {
+                            "type": "String",
+                            "keyRaw": "firstName"
+                        },
 
-		                "id": {
-		                    "type": "ID",
-		                    "keyRaw": "id"
-		                }
-		            },
+                        "id": {
+                            "type": "ID",
+                            "keyRaw": "id"
+                        }
+                    },
 
-		            "list": "All_Users",
+                    "list": "All_Users",
 
-		            "filters": {
-		                "stringValue": {
-		                    "kind": "Variable",
-		                    "value": "value"
-		                },
+                    "filters": {
+                        "stringValue": {
+                            "kind": "Variable",
+                            "value": "value"
+                        },
 
-		                "boolValue": {
-		                    "kind": "Boolean",
-		                    "value": true
-		                },
+                        "boolValue": {
+                            "kind": "Boolean",
+                            "value": true
+                        },
 
-		                "floatValue": {
-		                    "kind": "Float",
-		                    "value": 1.2
-		                },
+                        "floatValue": {
+                            "kind": "Float",
+                            "value": 1.2
+                        },
 
-		                "intValue": {
-		                    "kind": "Int",
-		                    "value": 1
-		                }
-		            }
-		        }
-		    },
+                        "intValue": {
+                            "kind": "Int",
+                            "value": 1
+                        }
+                    }
+                }
+            },
 
-		    input: {
-		        "fields": {
-		            "value": "String"
-		        },
+            input: {
+                "fields": {
+                    "value": "String"
+                },
 
-		        "types": {}
-		    }
-		};
-	`)
+                "types": {}
+            }
+        };
+    `)
 	})
 })
 
@@ -2260,15 +2287,15 @@ test('custom scalar shows up in artifact', async function () {
 	// define a config with a custom scalar
 	const localConfig = testConfig({
 		schema: `
-			scalar DateTime
-			type TodoItem {
-				text: String!
-				createdAt: DateTime!
-			}
-			type Query {
-				allItems: [TodoItem!]!
-			}
-		`,
+            scalar DateTime
+            type TodoItem {
+                text: String!
+                createdAt: DateTime!
+            }
+            type Query {
+                allItems: [TodoItem!]!
+            }
+        `,
 		scalars: {
 			DateTime: {
 				type: 'Date',
@@ -2297,90 +2324,91 @@ test('custom scalar shows up in artifact', async function () {
 	}).program
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "TestQuery",
-		    kind: "HoudiniQuery",
+        module.exports = {
+            name: "TestQuery",
+            kind: "HoudiniQuery",
+            hash: "b8314df1f7d924f76e6dfe6e7e3c8efd593db931c67c892311e97a9ec1d429b4",
 
-		    raw: \`query TestQuery {
-		  allItems {
-		    createdAt
-		  }
-		}
-		\`,
+            raw: \`query TestQuery {
+          allItems {
+            createdAt
+          }
+        }
+        \`,
 
-		    rootType: "Query",
+            rootType: "Query",
 
-		    selection: {
-		        "allItems": {
-		            "type": "TodoItem",
-		            "keyRaw": "allItems",
+            selection: {
+                "allItems": {
+                    "type": "TodoItem",
+                    "keyRaw": "allItems",
 
-		            "fields": {
-		                "createdAt": {
-		                    "type": "DateTime",
-		                    "keyRaw": "createdAt"
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                    "fields": {
+                        "createdAt": {
+                            "type": "DateTime",
+                            "keyRaw": "createdAt"
+                        }
+                    }
+                }
+            }
+        };
+    `)
 })
 
 test('operation inputs', async function () {
 	// the config to use in tests
 	const localConfig = testConfig({
 		schema: `
-		enum MyEnum {
-			Hello
-		}
+        enum MyEnum {
+            Hello
+        }
 
-		input UserFilter {
-			middle: NestedUserFilter
-			listRequired: [String!]!
-			nullList: [String]
-			recursive: UserFilter
-			enum: MyEnum
-		}
+        input UserFilter {
+            middle: NestedUserFilter
+            listRequired: [String!]!
+            nullList: [String]
+            recursive: UserFilter
+            enum: MyEnum
+        }
 
-		input NestedUserFilter {
-			id: ID!
-			firstName: String!
-			admin: Boolean
-			age: Int
-			weight: Float
-		}
+        input NestedUserFilter {
+            id: ID!
+            firstName: String!
+            admin: Boolean
+            age: Int
+            weight: Float
+        }
 
-		type User {
-			id: ID!
-		}
+        type User {
+            id: ID!
+        }
 
-		type Query {
-			user(id: ID, filter: UserFilter, filterList: [UserFilter!], enumArg: MyEnum): User
-		}
-	`,
+        type Query {
+            user(id: ID, filter: UserFilter, filterList: [UserFilter!], enumArg: MyEnum): User
+        }
+    `,
 	})
 
 	// execute the generator
 	await runPipeline(localConfig, [
 		mockCollectedDoc(
 			`
-			query TestQuery(
-				$id: ID,
-				$filter: UserFilter,
-				$filterList: [UserFilter!],
-				$enumArg: MyEnum
-			) {
-				user(
-					id: $id,
-					filter: $filter,
-					filterList: $filterList,
-					enumArg: $enumArg,
-				) {
-					id
-				}
-			}
-			`
+            query TestQuery(
+                $id: ID,
+                $filter: UserFilter,
+                $filterList: [UserFilter!],
+                $enumArg: MyEnum
+            ) {
+                user(
+                    id: $id,
+                    filter: $filter,
+                    filterList: $filterList,
+                    enumArg: $enumArg,
+                ) {
+                    id
+                }
+            }
+            `
 		),
 	])
 
@@ -2396,61 +2424,62 @@ test('operation inputs', async function () {
 	}).program
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "TestQuery",
-		    kind: "HoudiniQuery",
+        module.exports = {
+            name: "TestQuery",
+            kind: "HoudiniQuery",
+            hash: "f39d9c24c97c9c3cdcd916272e7ffb9d79cb4ad08ec294c829d647d4238c7e6b",
 
-		    raw: \`query TestQuery($id: ID, $filter: UserFilter, $filterList: [UserFilter!], $enumArg: MyEnum) {
-		  user(id: $id, filter: $filter, filterList: $filterList, enumArg: $enumArg) {
-		    id
-		  }
-		}
-		\`,
+            raw: \`query TestQuery($id: ID, $filter: UserFilter, $filterList: [UserFilter!], $enumArg: MyEnum) {
+          user(id: $id, filter: $filter, filterList: $filterList, enumArg: $enumArg) {
+            id
+          }
+        }
+        \`,
 
-		    rootType: "Query",
+            rootType: "Query",
 
-		    selection: {
-		        "user": {
-		            "type": "User",
-		            "keyRaw": "user(id: $id, filter: $filter, filterList: $filterList, enumArg: $enumArg)",
+            selection: {
+                "user": {
+                    "type": "User",
+                    "keyRaw": "user(id: $id, filter: $filter, filterList: $filterList, enumArg: $enumArg)",
 
-		            "fields": {
-		                "id": {
-		                    "type": "ID",
-		                    "keyRaw": "id"
-		                }
-		            }
-		        }
-		    },
+                    "fields": {
+                        "id": {
+                            "type": "ID",
+                            "keyRaw": "id"
+                        }
+                    }
+                }
+            },
 
-		    input: {
-		        "fields": {
-		            "id": "ID",
-		            "filter": "UserFilter",
-		            "filterList": "UserFilter",
-		            "enumArg": "MyEnum"
-		        },
+            input: {
+                "fields": {
+                    "id": "ID",
+                    "filter": "UserFilter",
+                    "filterList": "UserFilter",
+                    "enumArg": "MyEnum"
+                },
 
-		        "types": {
-		            "NestedUserFilter": {
-		                "id": "ID",
-		                "firstName": "String",
-		                "admin": "Boolean",
-		                "age": "Int",
-		                "weight": "Float"
-		            },
+                "types": {
+                    "NestedUserFilter": {
+                        "id": "ID",
+                        "firstName": "String",
+                        "admin": "Boolean",
+                        "age": "Int",
+                        "weight": "Float"
+                    },
 
-		            "UserFilter": {
-		                "middle": "NestedUserFilter",
-		                "listRequired": "String",
-		                "nullList": "String",
-		                "recursive": "UserFilter",
-		                "enum": "MyEnum"
-		            }
-		        }
-		    }
-		};
-	`)
+                    "UserFilter": {
+                        "middle": "NestedUserFilter",
+                        "listRequired": "String",
+                        "nullList": "String",
+                        "recursive": "UserFilter",
+                        "enum": "MyEnum"
+                    }
+                }
+            }
+        };
+    `)
 })
 
 describe('subscription artifacts', function () {
@@ -2458,12 +2487,12 @@ describe('subscription artifacts', function () {
 		const mutationDocs = [
 			mockCollectedDoc(
 				`subscription B {
-					newUser {
-						user {
-							firstName
-						}
-					}
-				}`
+                    newUser {
+                        user {
+                            firstName
+                        }
+                    }
+                }`
 			),
 		]
 
@@ -2482,48 +2511,49 @@ describe('subscription artifacts', function () {
 		}).program
 		// verify contents
 		expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "B",
-		    kind: "HoudiniSubscription",
+        module.exports = {
+            name: "B",
+            kind: "HoudiniSubscription",
+            hash: "755fb65bebc83835db68921b7e193809246fb6f9ee2e37cc66d7314b91a501e7",
 
-		    raw: \`subscription B {
-		  newUser {
-		    user {
-		      firstName
-		      id
-		    }
-		  }
-		}
-		\`,
+            raw: \`subscription B {
+          newUser {
+            user {
+              firstName
+              id
+            }
+          }
+        }
+        \`,
 
-		    rootType: "Subscription",
+            rootType: "Subscription",
 
-		    selection: {
-		        "newUser": {
-		            "type": "NewUserResult",
-		            "keyRaw": "newUser",
+            selection: {
+                "newUser": {
+                    "type": "NewUserResult",
+                    "keyRaw": "newUser",
 
-		            "fields": {
-		                "user": {
-		                    "type": "User",
-		                    "keyRaw": "user",
+                    "fields": {
+                        "user": {
+                            "type": "User",
+                            "keyRaw": "user",
 
-		                    "fields": {
-		                        "firstName": {
-		                            "type": "String",
-		                            "keyRaw": "firstName"
-		                        },
+                            "fields": {
+                                "firstName": {
+                                    "type": "String",
+                                    "keyRaw": "firstName"
+                                },
 
-		                        "id": {
-		                            "type": "ID",
-		                            "keyRaw": "id"
-		                        }
-		                    }
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                                "id": {
+                                    "type": "ID",
+                                    "keyRaw": "id"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    `)
 	})
 })

--- a/packages/houdini/cmd/generators/artifacts/index.ts
+++ b/packages/houdini/cmd/generators/artifacts/index.ts
@@ -153,6 +153,10 @@ export default async function artifactGenerator(config: Config, docs: CollectedG
 					AST.objectProperty(AST.identifier('name'), AST.stringLiteral(name)),
 					AST.objectProperty(AST.identifier('kind'), AST.stringLiteral(docKind)),
 					AST.objectProperty(
+						AST.identifier('hash'),
+						AST.stringLiteral(hashDocument(rawString))
+					),
+					AST.objectProperty(
 						AST.identifier('raw'),
 						AST.templateLiteral(
 							[AST.templateElement({ raw: rawString, cooked: rawString }, true)],

--- a/packages/houdini/cmd/generators/index.ts
+++ b/packages/houdini/cmd/generators/index.ts
@@ -1,3 +1,4 @@
+export { default as persistOutput } from './persisted-queries'
 export { default as artifacts } from './artifacts'
 export { default as runtime } from './runtime'
 export { default as typescript } from './typescript'

--- a/packages/houdini/cmd/generators/persisted-queries/index.ts
+++ b/packages/houdini/cmd/generators/persisted-queries/index.ts
@@ -1,0 +1,50 @@
+//externals
+import { Config, hashDocument } from 'houdini-common'
+import * as graphql from 'graphql'
+import { writeFile } from 'fs/promises'
+// internals
+import { CollectedGraphQLDocument } from '../../types'
+
+// the persist output generator is responsible for generating a queryMap.json
+// to the provided path with the `hash` as key and the raw query as value.
+export default async function persistOutputGenerator(
+	config: Config,
+	docs: CollectedGraphQLDocument[]
+) {
+	if (!config.outputPath || config.outputPath.length === 0) return
+
+	const queryMap = docs.reduce<Record<string, string>>((acc, { document, generated }) => {
+		// if the document is generated, don't write it to disk - it's use is to provide definitions
+		// for the other transforms
+		if (generated) {
+			return acc
+		}
+
+		// before we can print the document, we need to strip all references to internal directives
+		let rawString = graphql.print(
+			graphql.visit(document, {
+				Directive(node) {
+					// if the directive is one of the internal ones, remove it
+					if (config.isInternalDirective(node)) {
+						return null
+					}
+				},
+			})
+		)
+
+		const operations = document.definitions.filter(
+			({ kind }) => kind === graphql.Kind.OPERATION_DEFINITION
+		) as graphql.OperationDefinitionNode[]
+
+		// if there are operations in the document
+		if (operations.length > 0 && operations[0].kind === 'OperationDefinition') {
+			acc[hashDocument(rawString)] = rawString
+		}
+
+		return acc
+	}, {})
+
+	if (Object.keys(queryMap).length === 0) return
+
+	await writeFile(config.outputPath, JSON.stringify(queryMap), 'utf-8')
+}

--- a/packages/houdini/cmd/main.ts
+++ b/packages/houdini/cmd/main.ts
@@ -17,34 +17,42 @@ program
 	.command('generate')
 	.description('generate the application runtime')
 	.option('-p, --pull-schema', 'pull the latest schema before generating')
-	.action(async (args: { pullSchema: boolean } = { pullSchema: false }) => {
-		// grab the config file
-		const config = await getConfig()
+	.option('-po, --persist-output [outputPath]', 'persist the queries')
+	.action(
+		async (args: { pullSchema: boolean; persistOutput?: string } = { pullSchema: false }) => {
+			// grab the config file
+			const config = await getConfig()
 
-		try {
-			// Pull the newest schema if the flag is set
-			if (args.pullSchema) {
-				// Check if apiUrl is set in config
-				if (!config.apiUrl) {
-					throw new Error(
-						'Your config should contain a valid apiUrl to pull the latest schema.'
-					)
+			try {
+				if (args.persistOutput) {
+					config.outputPath = args.persistOutput
 				}
-				// The target path -> current working directory by default. Should we allow passing custom paths?
-				const targetPath = process.cwd()
-				// Write the schema
-				const schema = await writeSchema(
-					config.apiUrl,
-					config.schemaPath ? config.schemaPath : path.resolve(targetPath, 'schema.json')
-				)
-				// Set the newly written schema into the config
-				config.schema = schema
+				// Pull the newest schema if the flag is set
+				if (args.pullSchema) {
+					// Check if apiUrl is set in config
+					if (!config.apiUrl) {
+						throw new Error(
+							'Your config should contain a valid apiUrl to pull the latest schema.'
+						)
+					}
+					// The target path -> current working directory by default. Should we allow passing custom paths?
+					const targetPath = process.cwd()
+					// Write the schema
+					const schema = await writeSchema(
+						config.apiUrl,
+						config.schemaPath
+							? config.schemaPath
+							: path.resolve(targetPath, 'schema.json')
+					)
+					// Set the newly written schema into the config
+					config.schema = schema
+				}
+				await generate(config)
+			} catch (e) {
+				console.error(e)
 			}
-			await generate(config)
-		} catch (e) {
-			console.error(e)
 		}
-	})
+	)
 
 // register the init command
 program.command('init [path]').description('initialize a new houdini project').action(init)

--- a/packages/houdini/cmd/main.ts
+++ b/packages/houdini/cmd/main.ts
@@ -17,7 +17,7 @@ program
 	.command('generate')
 	.description('generate the application runtime')
 	.option('-p, --pull-schema', 'pull the latest schema before generating')
-	.option('-po, --persist-output [outputPath]', 'persist the queries')
+	.option('-po, --persist-output [outputPath]', 'persist queries to a queryMap file')
 	.action(
 		async (args: { pullSchema: boolean; persistOutput?: string } = { pullSchema: false }) => {
 			// grab the config file

--- a/packages/houdini/cmd/transforms/fragmentVariables.test.ts
+++ b/packages/houdini/cmd/transforms/fragmentVariables.test.ts
@@ -14,20 +14,20 @@ test('pass argument values to generated fragments', async function () {
 	const docs = [
 		mockCollectedDoc(
 			`
-				query AllUsers {
+                query AllUsers {
                     ...QueryFragment @with(name: "Hello")
-				}
-			`
+                }
+            `
 		),
 		mockCollectedDoc(
 			`
-				fragment QueryFragment on Query 
+                fragment QueryFragment on Query 
                 @arguments(name: {type: "String"} ) {
                     users(stringValue: $name) { 
                         id
                     }
-				}
-			`
+                }
+            `
 		),
 	]
 
@@ -46,58 +46,59 @@ test('pass argument values to generated fragments', async function () {
 	}).program
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "AllUsers",
-		    kind: "HoudiniQuery",
+        module.exports = {
+            name: "AllUsers",
+            kind: "HoudiniQuery",
+            hash: "c346b9eaafaa74d18a267a74706e193e8080b9533d994d6e8489d7e5b534ee41",
 
-		    raw: \`query AllUsers {
-		  ...QueryFragment_10b3uv
-		}
+            raw: \`query AllUsers {
+          ...QueryFragment_10b3uv
+        }
 
-		fragment QueryFragment_10b3uv on Query {
-		  users(stringValue: "Hello") {
-		    id
-		  }
-		}
-		\`,
+        fragment QueryFragment_10b3uv on Query {
+          users(stringValue: "Hello") {
+            id
+          }
+        }
+        \`,
 
-		    rootType: "Query",
+            rootType: "Query",
 
-		    selection: {
-		        "users": {
-		            "type": "User",
-		            "keyRaw": "users(stringValue: \\"Hello\\")",
+            selection: {
+                "users": {
+                    "type": "User",
+                    "keyRaw": "users(stringValue: \\"Hello\\")",
 
-		            "fields": {
-		                "id": {
-		                    "type": "ID",
-		                    "keyRaw": "id"
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                    "fields": {
+                        "id": {
+                            "type": "ID",
+                            "keyRaw": "id"
+                        }
+                    }
+                }
+            }
+        };
+    `)
 })
 
 test("fragment arguments with default values don't rename the fragment", async function () {
 	const docs = [
 		mockCollectedDoc(
 			`
-				query AllUsers {
+                query AllUsers {
                     ...QueryFragment
-				}
-			`
+                }
+            `
 		),
 		mockCollectedDoc(
 			`
-				fragment QueryFragment on Query 
+                fragment QueryFragment on Query 
                 @arguments(name: {type: "String", default: "Hello"}) {
                     users(stringValue: $name) { 
                         id
                     }
-				}
-			`
+                }
+            `
 		),
 	]
 
@@ -116,66 +117,67 @@ test("fragment arguments with default values don't rename the fragment", async f
 	}).program
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "AllUsers",
-		    kind: "HoudiniQuery",
+        module.exports = {
+            name: "AllUsers",
+            kind: "HoudiniQuery",
+            hash: "3835ee68277547d738cc8fd5051fe98799b5bd470516146906fa0f134a2b3891",
 
-		    raw: \`query AllUsers {
-		  ...QueryFragment
-		}
+            raw: \`query AllUsers {
+          ...QueryFragment
+        }
 
-		fragment QueryFragment on Query {
-		  users(stringValue: "Hello") {
-		    id
-		  }
-		}
-		\`,
+        fragment QueryFragment on Query {
+          users(stringValue: "Hello") {
+            id
+          }
+        }
+        \`,
 
-		    rootType: "Query",
+            rootType: "Query",
 
-		    selection: {
-		        "users": {
-		            "type": "User",
-		            "keyRaw": "users(stringValue: \\"Hello\\")",
+            selection: {
+                "users": {
+                    "type": "User",
+                    "keyRaw": "users(stringValue: \\"Hello\\")",
 
-		            "fields": {
-		                "id": {
-		                    "type": "ID",
-		                    "keyRaw": "id"
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                    "fields": {
+                        "id": {
+                            "type": "ID",
+                            "keyRaw": "id"
+                        }
+                    }
+                }
+            }
+        };
+    `)
 })
 
 test('thread query variables to inner fragments', async function () {
 	const docs = [
 		mockCollectedDoc(
 			`
-				query AllUsers($name: String!) {
+                query AllUsers($name: String!) {
                     ...QueryFragment @with(name: $name)
-				}
-			`
+                }
+            `
 		),
 		mockCollectedDoc(
 			`
-				fragment QueryFragment on Query 
+                fragment QueryFragment on Query 
                 @arguments(name: {type: "String", default: "Hello"}) {
                     ...InnerFragment @with(name: $name)
-				}
-			`
+                }
+            `
 		),
 		mockCollectedDoc(
 			`
-				fragment InnerFragment on Query 
+                fragment InnerFragment on Query 
                 @arguments(name: {type: "String", default: "Hello"}) {
                     users(stringValue: $name) { 
                         id
                     }
-				}
-			`
+                }
+            `
 		),
 	]
 
@@ -194,78 +196,79 @@ test('thread query variables to inner fragments', async function () {
 	}).program
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "AllUsers",
-		    kind: "HoudiniQuery",
+        module.exports = {
+            name: "AllUsers",
+            kind: "HoudiniQuery",
+            hash: "8fa4273ab75455c901e7de893f72a28af4c001afbf204ceca2fd7ab30b7ff372",
 
-		    raw: \`query AllUsers($name: String!) {
-		  ...QueryFragment_VDHGm
-		}
+            raw: \`query AllUsers($name: String!) {
+          ...QueryFragment_VDHGm
+        }
 
-		fragment QueryFragment_VDHGm on Query {
-		  ...InnerFragment_VDHGm
-		}
+        fragment QueryFragment_VDHGm on Query {
+          ...InnerFragment_VDHGm
+        }
 
-		fragment InnerFragment_VDHGm on Query {
-		  users(stringValue: $name) {
-		    id
-		  }
-		}
-		\`,
+        fragment InnerFragment_VDHGm on Query {
+          users(stringValue: $name) {
+            id
+          }
+        }
+        \`,
 
-		    rootType: "Query",
+            rootType: "Query",
 
-		    selection: {
-		        "users": {
-		            "type": "User",
-		            "keyRaw": "users(stringValue: $name)",
+            selection: {
+                "users": {
+                    "type": "User",
+                    "keyRaw": "users(stringValue: $name)",
 
-		            "fields": {
-		                "id": {
-		                    "type": "ID",
-		                    "keyRaw": "id"
-		                }
-		            }
-		        }
-		    },
+                    "fields": {
+                        "id": {
+                            "type": "ID",
+                            "keyRaw": "id"
+                        }
+                    }
+                }
+            },
 
-		    input: {
-		        "fields": {
-		            "name": "String"
-		        },
+            input: {
+                "fields": {
+                    "name": "String"
+                },
 
-		        "types": {}
-		    }
-		};
-	`)
+                "types": {}
+            }
+        };
+    `)
 })
 
 test('inner fragment with intermediate default value', async function () {
 	const docs = [
 		mockCollectedDoc(
 			`
-				query AllUsers {
+                query AllUsers {
                     ...QueryFragment
-				}
-			`
+                }
+            `
 		),
 		mockCollectedDoc(
 			`
-				fragment QueryFragment on Query 
+                fragment QueryFragment on Query 
                 @arguments(name: {type: "String", default: "Hello"}) {
                     ...InnerFragment @with(name: $name)
-				}
-			`
+                }
+            `
 		),
 		mockCollectedDoc(
 			`
-				fragment InnerFragment on Query 
+                fragment InnerFragment on Query 
                 @arguments(name: {type: "String", default: "Goodbye"}, age: {type: "Int", default: 2}) {
                     users(stringValue: $name, intValue: $age) { 
                         id
                     }
-				}
-			`
+                }
+            `
 		),
 	]
 
@@ -284,70 +287,71 @@ test('inner fragment with intermediate default value', async function () {
 	}).program
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "AllUsers",
-		    kind: "HoudiniQuery",
+        module.exports = {
+            name: "AllUsers",
+            kind: "HoudiniQuery",
+            hash: "d5753a3cae56b8133c72527cdccdd0c001effb48104b98806ac62dd9afeeb259",
 
-		    raw: \`query AllUsers {
-		  ...QueryFragment
-		}
+            raw: \`query AllUsers {
+          ...QueryFragment
+        }
 
-		fragment QueryFragment on Query {
-		  ...InnerFragment_10b3uv
-		}
+        fragment QueryFragment on Query {
+          ...InnerFragment_10b3uv
+        }
 
-		fragment InnerFragment_10b3uv on Query {
-		  users(stringValue: "Hello", intValue: 2) {
-		    id
-		  }
-		}
-		\`,
+        fragment InnerFragment_10b3uv on Query {
+          users(stringValue: "Hello", intValue: 2) {
+            id
+          }
+        }
+        \`,
 
-		    rootType: "Query",
+            rootType: "Query",
 
-		    selection: {
-		        "users": {
-		            "type": "User",
-		            "keyRaw": "users(stringValue: \\"Hello\\", intValue: 2)",
+            selection: {
+                "users": {
+                    "type": "User",
+                    "keyRaw": "users(stringValue: \\"Hello\\", intValue: 2)",
 
-		            "fields": {
-		                "id": {
-		                    "type": "ID",
-		                    "keyRaw": "id"
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                    "fields": {
+                        "id": {
+                            "type": "ID",
+                            "keyRaw": "id"
+                        }
+                    }
+                }
+            }
+        };
+    `)
 })
 
 test("default values don't overwrite unless explicitly passed", async function () {
 	const docs = [
 		mockCollectedDoc(
 			`
-				query AllUsers {
+                query AllUsers {
                     ...QueryFragment
-				}
-			`
+                }
+            `
 		),
 		mockCollectedDoc(
 			`
-				fragment QueryFragment on Query 
+                fragment QueryFragment on Query 
                 @arguments(name: {type: "String", default: "Hello"}) {
                     ...InnerFragment
-				}
-			`
+                }
+            `
 		),
 		mockCollectedDoc(
 			`
-				fragment InnerFragment on Query 
+                fragment InnerFragment on Query 
                 @arguments(name: {type: "String", default: "Goodbye"}) {
                     users(stringValue: $name) { 
                         id
                     }
-				}
-			`
+                }
+            `
 		),
 	]
 
@@ -366,62 +370,63 @@ test("default values don't overwrite unless explicitly passed", async function (
 	}).program
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "AllUsers",
-		    kind: "HoudiniQuery",
+        module.exports = {
+            name: "AllUsers",
+            kind: "HoudiniQuery",
+            hash: "65064d681cee9e6381a4f63605c9f33f7d6348fc6a7ac010f3f8ea6fabf3c8ee",
 
-		    raw: \`query AllUsers {
-		  ...QueryFragment
-		}
+            raw: \`query AllUsers {
+          ...QueryFragment
+        }
 
-		fragment QueryFragment on Query {
-		  ...InnerFragment
-		}
+        fragment QueryFragment on Query {
+          ...InnerFragment
+        }
 
-		fragment InnerFragment on Query {
-		  users(stringValue: "Goodbye") {
-		    id
-		  }
-		}
-		\`,
+        fragment InnerFragment on Query {
+          users(stringValue: "Goodbye") {
+            id
+          }
+        }
+        \`,
 
-		    rootType: "Query",
+            rootType: "Query",
 
-		    selection: {
-		        "users": {
-		            "type": "User",
-		            "keyRaw": "users(stringValue: \\"Goodbye\\")",
+            selection: {
+                "users": {
+                    "type": "User",
+                    "keyRaw": "users(stringValue: \\"Goodbye\\")",
 
-		            "fields": {
-		                "id": {
-		                    "type": "ID",
-		                    "keyRaw": "id"
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                    "fields": {
+                        "id": {
+                            "type": "ID",
+                            "keyRaw": "id"
+                        }
+                    }
+                }
+            }
+        };
+    `)
 })
 
 test('default arguments', async function () {
 	const docs = [
 		mockCollectedDoc(
 			`
-				query AllUsers {
+                query AllUsers {
                     ...QueryFragment
-				}
-			`
+                }
+            `
 		),
 		mockCollectedDoc(
 			`
-				fragment QueryFragment on Query 
+                fragment QueryFragment on Query 
                 @arguments(name: {type: "String", default: "Hello"}, cool: {type: "Boolean", default: true}) {
                     users(boolValue: $cool, stringValue: $name) { 
-						id
-					}
-				}
-			`
+                        id
+                    }
+                }
+            `
 		),
 	]
 
@@ -440,58 +445,59 @@ test('default arguments', async function () {
 	}).program
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "AllUsers",
-		    kind: "HoudiniQuery",
+        module.exports = {
+            name: "AllUsers",
+            kind: "HoudiniQuery",
+            hash: "5c4a8d1fe2e117286ecdfbd273bf1beb2f71a0a3fd9ea6bc84fe97c394c1a836",
 
-		    raw: \`query AllUsers {
-		  ...QueryFragment
-		}
+            raw: \`query AllUsers {
+          ...QueryFragment
+        }
 
-		fragment QueryFragment on Query {
-		  users(boolValue: true, stringValue: "Hello") {
-		    id
-		  }
-		}
-		\`,
+        fragment QueryFragment on Query {
+          users(boolValue: true, stringValue: "Hello") {
+            id
+          }
+        }
+        \`,
 
-		    rootType: "Query",
+            rootType: "Query",
 
-		    selection: {
-		        "users": {
-		            "type": "User",
-		            "keyRaw": "users(boolValue: true, stringValue: \\"Hello\\")",
+            selection: {
+                "users": {
+                    "type": "User",
+                    "keyRaw": "users(boolValue: true, stringValue: \\"Hello\\")",
 
-		            "fields": {
-		                "id": {
-		                    "type": "ID",
-		                    "keyRaw": "id"
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                    "fields": {
+                        "id": {
+                            "type": "ID",
+                            "keyRaw": "id"
+                        }
+                    }
+                }
+            }
+        };
+    `)
 })
 
 test('multiple with directives - no overlap', async function () {
 	const docs = [
 		mockCollectedDoc(
 			`
-				query AllUsers {
+                query AllUsers {
                     ...QueryFragment @with(name: "Goodbye") @with(cool: false)
-				}
-			`
+                }
+            `
 		),
 		mockCollectedDoc(
 			`
-				fragment QueryFragment on Query 
+                fragment QueryFragment on Query 
                 @arguments(name: {type: "String", default: "Hello"}, cool: {type: "Boolean", default: true}) {
                     users(boolValue: $cool, stringValue: $name) { 
-						id
-					}
-				}
-			`
+                        id
+                    }
+                }
+            `
 		),
 	]
 
@@ -510,36 +516,37 @@ test('multiple with directives - no overlap', async function () {
 	}).program
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		module.exports = {
-		    name: "AllUsers",
-		    kind: "HoudiniQuery",
+        module.exports = {
+            name: "AllUsers",
+            kind: "HoudiniQuery",
+            hash: "7327e6f7f6c8339feebb640b995c3e25efe1b25de29b1f43cb55c2a0566f713f",
 
-		    raw: \`query AllUsers {
-		  ...QueryFragment_2prn0K
-		}
+            raw: \`query AllUsers {
+          ...QueryFragment_2prn0K
+        }
 
-		fragment QueryFragment_2prn0K on Query {
-		  users(boolValue: false, stringValue: "Goodbye") {
-		    id
-		  }
-		}
-		\`,
+        fragment QueryFragment_2prn0K on Query {
+          users(boolValue: false, stringValue: "Goodbye") {
+            id
+          }
+        }
+        \`,
 
-		    rootType: "Query",
+            rootType: "Query",
 
-		    selection: {
-		        "users": {
-		            "type": "User",
-		            "keyRaw": "users(boolValue: false, stringValue: \\"Goodbye\\")",
+            selection: {
+                "users": {
+                    "type": "User",
+                    "keyRaw": "users(boolValue: false, stringValue: \\"Goodbye\\")",
 
-		            "fields": {
-		                "id": {
-		                    "type": "ID",
-		                    "keyRaw": "id"
-		                }
-		            }
-		        }
-		    }
-		};
-	`)
+                    "fields": {
+                        "id": {
+                            "type": "ID",
+                            "keyRaw": "id"
+                        }
+                    }
+                }
+            }
+        };
+    `)
 })

--- a/packages/houdini/runtime/network.ts
+++ b/packages/houdini/runtime/network.ts
@@ -42,6 +42,7 @@ export type SubscriptionHandler = {
 
 export type FetchParams = {
 	text: string
+	hash: string
 	variables: { [key: string]: any }
 }
 
@@ -110,12 +111,13 @@ export async function executeQuery<_Data>(
 	}
 
 	// pull the query text out of the compiled artifact
-	const { raw: text } = artifact
+	const { raw: text, hash } = artifact
 
 	const res = await fetchQuery<_Data>(
 		fetchCtx,
 		{
 			text,
+			hash,
 			variables,
 		},
 		session
@@ -137,9 +139,11 @@ export async function fetchQuery<_Data>(
 	ctx: FetchContext,
 	{
 		text,
+		hash,
 		variables,
 	}: {
 		text: string
+		hash: string
 		variables: { [name: string]: unknown }
 	},
 	session?: FetchSession
@@ -151,7 +155,7 @@ export async function fetchQuery<_Data>(
 		return { data: {}, errors: [{ message: 'could not find houdini environment' }] }
 	}
 
-	return await environment.sendRequest<_Data>(ctx, { text, variables }, session)
+	return await environment.sendRequest<_Data>(ctx, { text, hash, variables }, session)
 }
 
 // convertKitPayload is responsible for taking the result of kit's load

--- a/yarn.lock
+++ b/yarn.lock
@@ -5703,8 +5703,8 @@ __metadata:
     "@sveltejs/kit": 1.0.0-next.107
     apollo-server: ^2.24.0
     graphql: 15.5.0
-    houdini: ^0.7.1
-    houdini-preprocess: ^0.7.1
+    houdini: ^0.9.7
+    houdini-preprocess: ^0.9.7
     subscriptions-transport-ws: ^0.9.18
     svelte: ^3.38.2
     svelte-preprocess: ^4.0.0
@@ -6706,7 +6706,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"houdini-common@^0.7.0, houdini-common@workspace:packages/houdini-common":
+"houdini-common@^0.9.0, houdini-common@workspace:packages/houdini-common":
   version: 0.0.0-use.local
   resolution: "houdini-common@workspace:packages/houdini-common"
   dependencies:
@@ -6751,7 +6751,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"houdini-preprocess@^0.7.1, houdini-preprocess@workspace:packages/houdini-preprocess":
+"houdini-preprocess@^0.9.7, houdini-preprocess@workspace:packages/houdini-preprocess":
   version: 0.0.0-use.local
   resolution: "houdini-preprocess@workspace:packages/houdini-preprocess"
   dependencies:
@@ -6765,8 +6765,8 @@ __metadata:
     babylon: ^7.0.0-beta.47
     estree-walker: ^2.0.2
     graphql: 15.5.0
-    houdini: ^0.7.1
-    houdini-common: ^0.7.0
+    houdini: ^0.9.7
+    houdini-common: ^0.9.0
     jest: ^26.6.3
     mkdirp: ^1.0.4
     prettier: "*"
@@ -6777,7 +6777,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"houdini@^0.7.1, houdini@workspace:packages/houdini":
+"houdini@^0.9.7, houdini@workspace:packages/houdini":
   version: 0.0.0-use.local
   resolution: "houdini@workspace:packages/houdini"
   dependencies:
@@ -6798,7 +6798,7 @@ __metadata:
     estree-walker: ^2.0.2
     glob: ^7.1.6
     graphql: ^15.5.0
-    houdini-common: ^0.7.0
+    houdini-common: ^0.9.0
     inquirer: ^7.3.3
     jest: ^26.6.3
     mkdirp: ^1.0.4


### PR DESCRIPTION
## This implements persisted queries!

I added a `--persist-output` flag to the `generate` command, which can be used to write a `queryMap` to the provided location in json format.

I'm using the `hashDocument` function again and updated it to use `sha256` instead of `md5` since this is what apollo server expects.

I'm passing the hash to the `environments` fetch function, this opens up for 2 different persisted query approaches.

- [Apollo Style](https://github.com/apollographql/apollo-link-persisted-queries#apollo-engine)
- [Relay Style](https://relay.dev/docs/guides/persisted-queries/)

I personally prefer the `--persist-output` option because i'm not using apollo in any ways but this let's the user decide.

The `--persist-output` flag is not required for the `apollo style`.

I'm open to any changes, renames etc.