### PR TITLE
Use node version >=14.13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
             - name: Setup Node 14
               uses: actions/setup-node@v1
               with:
-                  node-version: 14.2
+                  node-version: 14.13
                   registry-url: 'https://npm.pkg.github.com'
 
             - name: Set Git Identity

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,10 @@ jobs:
               run: |
                   git checkout ${{ github.event.pull_request.base.ref }}
 
-            - name: Setup Node 15
+            - name: Setup Node 14
               uses: actions/setup-node@v1
               with:
-                  node-version: 15
+                  node-version: 14.2
                   registry-url: 'https://npm.pkg.github.com'
 
             - name: Set Git Identity

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,10 +18,10 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - name: Use Node.js 14.2
+            - name: Use Node.js 14.13
               uses: actions/setup-node@v1
               with:
-                  node-version: 14.2
+                  node-version: 14.13
 
             - name: Checkout source
               uses: actions/checkout@master
@@ -39,10 +39,10 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - name: Use Node.js 14.2
+            - name: Use Node.js 14.13
               uses: actions/setup-node@v1
               with:
-                  node-version: 14.2
+                  node-version: 14.13
 
             - name: Checkout source
               uses: actions/checkout@master
@@ -63,10 +63,10 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - name: Use Node.js 14.2
+            - name: Use Node.js 14.13
               uses: actions/setup-node@v1
               with:
-                  node-version: 14.2
+                  node-version: 14.13
 
             - name: Checkout source
               uses: actions/checkout@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,10 +18,10 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - name: Use Node.js 15.x
+            - name: Use Node.js 14.2
               uses: actions/setup-node@v1
               with:
-                  node-version: 15.x
+                  node-version: 14.2
 
             - name: Checkout source
               uses: actions/checkout@master
@@ -39,10 +39,10 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - name: Use Node.js 15.x
+            - name: Use Node.js 14.2
               uses: actions/setup-node@v1
               with:
-                  node-version: 15.x
+                  node-version: 14.2
 
             - name: Checkout source
               uses: actions/checkout@master
@@ -63,10 +63,10 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - name: Use Node.js 15.x
+            - name: Use Node.js 14.2
               uses: actions/setup-node@v1
               with:
-                  node-version: 15.x
+                  node-version: 14.2
 
             - name: Checkout source
               uses: actions/checkout@master

--- a/packages/houdini/package.json
+++ b/packages/houdini/package.json
@@ -18,7 +18,7 @@
 	"author": "",
 	"license": "ISC",
 	"engines": {
-		"node": ">=15"
+		"node": ">=14.2"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.12.10",

--- a/packages/houdini/package.json
+++ b/packages/houdini/package.json
@@ -18,7 +18,7 @@
 	"author": "",
 	"license": "ISC",
 	"engines": {
-		"node": ">=14.2"
+		"node": ">=14.13"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.12.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5703,8 +5703,8 @@ __metadata:
     "@sveltejs/kit": 1.0.0-next.107
     apollo-server: ^2.24.0
     graphql: 15.5.0
-    houdini: ^0.7.1
-    houdini-preprocess: ^0.7.1
+    houdini: ^0.9.7
+    houdini-preprocess: ^0.9.7
     subscriptions-transport-ws: ^0.9.18
     svelte: ^3.38.2
     svelte-preprocess: ^4.0.0
@@ -6706,7 +6706,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"houdini-common@^0.7.0, houdini-common@workspace:packages/houdini-common":
+"houdini-common@^0.9.0, houdini-common@workspace:packages/houdini-common":
   version: 0.0.0-use.local
   resolution: "houdini-common@workspace:packages/houdini-common"
   dependencies:
@@ -6751,7 +6751,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"houdini-preprocess@^0.7.1, houdini-preprocess@workspace:packages/houdini-preprocess":
+"houdini-preprocess@^0.9.7, houdini-preprocess@workspace:packages/houdini-preprocess":
   version: 0.0.0-use.local
   resolution: "houdini-preprocess@workspace:packages/houdini-preprocess"
   dependencies:
@@ -6765,8 +6765,8 @@ __metadata:
     babylon: ^7.0.0-beta.47
     estree-walker: ^2.0.2
     graphql: 15.5.0
-    houdini: ^0.7.1
-    houdini-common: ^0.7.0
+    houdini: ^0.9.7
+    houdini-common: ^0.9.0
     jest: ^26.6.3
     mkdirp: ^1.0.4
     prettier: "*"
@@ -6777,7 +6777,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"houdini@^0.7.1, houdini@workspace:packages/houdini":
+"houdini@^0.9.7, houdini@workspace:packages/houdini":
   version: 0.0.0-use.local
   resolution: "houdini@workspace:packages/houdini"
   dependencies:
@@ -6798,7 +6798,7 @@ __metadata:
     estree-walker: ^2.0.2
     glob: ^7.1.6
     graphql: ^15.5.0
-    houdini-common: ^0.7.0
+    houdini-common: ^0.9.0
     inquirer: ^7.3.3
     jest: ^26.6.3
     mkdirp: ^1.0.4


### PR DESCRIPTION
It seems that node version >=14.13 does not reintroduce the problems in #103, and allows for support for Vercel as discussed in #137.
Have tried version 14.12 and below, and there are issues with the graphql Kind export, and maybe others, as can be seen in the CI checks for the first commit.