### PR TITLE
Fix bug when unsubscribing to recursive linked lists

### DIFF
--- a/packages/houdini/runtime/cache/cache.test.ts
+++ b/packages/houdini/runtime/cache/cache.test.ts
@@ -3178,6 +3178,94 @@ test('can write list of scalars', function () {
 	})
 })
 
+test('self-referencing linked lists can be unsubscribed (avoid infinite recursion)', function () {
+	// instantiate the cache
+	const cache = new Cache(config)
+
+	const selection = {
+		viewer: {
+			type: 'User',
+			keyRaw: 'viewer',
+			fields: {
+				id: {
+					type: 'ID',
+					keyRaw: 'id',
+				},
+				firstName: {
+					type: 'String',
+					keyRaw: 'firstName',
+				},
+				friends: {
+					type: 'User',
+					keyRaw: 'friends',
+					fields: {
+						id: {
+							type: 'ID',
+							keyRaw: 'id',
+						},
+						firstName: {
+							type: 'String',
+							keyRaw: 'firstName',
+						},
+						friends: {
+							type: 'User',
+							keyRaw: 'friends',
+							fields: {
+								id: {
+									type: 'ID',
+									keyRaw: 'id',
+								},
+								firstName: {
+									type: 'String',
+									keyRaw: 'firstName',
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// add some data to the cache
+	cache.write(
+		selection,
+		{
+			viewer: {
+				id: '1',
+				firstName: 'bob',
+				friends: [
+					{
+						id: '1',
+						firstName: 'bob',
+						friends: [
+							{
+								id: '1',
+								firstName: 'bob',
+							},
+						],
+					},
+				],
+			},
+		},
+		{}
+	)
+
+	// subscribe to the list
+	const spec = {
+		set: jest.fn(),
+		selection,
+		rootType: 'Query',
+	}
+	cache.subscribe(spec)
+	cache.unsubscribe(spec)
+
+	// no one should be subscribing to User:1's first name
+	expect(
+		cache.internal.getRecord(cache.id('User', '1')!)?.getSubscribers('firstName')
+	).toHaveLength(0)
+})
+
 test.todo('inserting node creates back reference to list')
 
 test.todo('unsubscribe removes list handlers')

--- a/packages/houdini/runtime/cache/cache.test.ts
+++ b/packages/houdini/runtime/cache/cache.test.ts
@@ -3266,6 +3266,108 @@ test('self-referencing linked lists can be unsubscribed (avoid infinite recursio
 	).toHaveLength(0)
 })
 
+test('self-referencing links can be unsubscribed (avoid infinite recursion)', function () {
+	// instantiate the cache
+	const cache = new Cache(config)
+
+	const selection = {
+		viewer: {
+			type: 'User',
+			keyRaw: 'viewer',
+			fields: {
+				id: {
+					type: 'ID',
+					keyRaw: 'id',
+				},
+				firstName: {
+					type: 'String',
+					keyRaw: 'firstName',
+				},
+				friend: {
+					type: 'User',
+					keyRaw: 'friend',
+					fields: {
+						id: {
+							type: 'ID',
+							keyRaw: 'id',
+						},
+						firstName: {
+							type: 'String',
+							keyRaw: 'firstName',
+						},
+						friend: {
+							type: 'User',
+							keyRaw: 'friend',
+							fields: {
+								id: {
+									type: 'ID',
+									keyRaw: 'id',
+								},
+								firstName: {
+									type: 'String',
+									keyRaw: 'firstName',
+								},
+								friend: {
+									type: 'User',
+									keyRaw: 'friend',
+									fields: {
+										id: {
+											type: 'ID',
+											keyRaw: 'id',
+										},
+										firstName: {
+											type: 'String',
+											keyRaw: 'firstName',
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// add some data to the cache
+	cache.write(
+		selection,
+		{
+			viewer: {
+				id: '1',
+				firstName: 'bob',
+				friend: {
+					id: '1',
+					firstName: 'bob',
+					friend: {
+						id: '1',
+						firstName: 'bob',
+						friend: {
+							id: '1',
+							firstName: 'bob',
+						},
+					},
+				},
+			},
+		},
+		{}
+	)
+
+	// subscribe to the list
+	const spec = {
+		set: jest.fn(),
+		selection,
+		rootType: 'Query',
+	}
+	cache.subscribe(spec)
+	cache.unsubscribe(spec)
+
+	// no one should be subscribing to User:1's first name
+	expect(
+		cache.internal.getRecord(cache.id('User', '1')!)?.getSubscribers('firstName')
+	).toHaveLength(0)
+})
+
 test.todo('inserting node creates back reference to list')
 
 test.todo('unsubscribe removes list handlers')

--- a/packages/houdini/runtime/cache/cache.ts
+++ b/packages/houdini/runtime/cache/cache.ts
@@ -125,7 +125,7 @@ export class Cache {
 	private record(id: string | undefined): Record {
 		// if we haven't seen the record before add an entry in the store
 		if (!this._data.has(id)) {
-			this._data.set(id, new Record(this))
+			this._data.set(id, new Record(this, id || ''))
 		}
 
 		// write the field value


### PR DESCRIPTION
This PR fixes the bug reported in #141 which would trigger when there was a self-reference inside of a linked list