### PR TITLE
Feat: Export type ConfigFile to enable typable configs + code completion

### DIFF
--- a/example/houdini.config.js
+++ b/example/houdini.config.js
@@ -1,4 +1,5 @@
-export default {
+/** @type {import('houdini/build/runtime').ConfigFile} */
+const config = {
 	schemaPath: './schema/schema.gql',
 	sourceGlob: 'src/**/*.svelte',
 	framework: 'kit',
@@ -16,3 +17,5 @@ export default {
 		},
 	},
 }
+
+export default config

--- a/example/houdini.config.js
+++ b/example/houdini.config.js
@@ -1,4 +1,4 @@
-/** @type {import('houdini/build/runtime').ConfigFile} */
+/** @type {import('houdini').ConfigFile} */
 const config = {
 	schemaPath: './schema/schema.gql',
 	sourceGlob: 'src/**/*.svelte',

--- a/example/houdini.config.js
+++ b/example/houdini.config.js
@@ -1,5 +1,5 @@
 /** @type {import('houdini').ConfigFile} */
-const config = {
+export default {
 	schemaPath: './schema/schema.gql',
 	sourceGlob: 'src/**/*.svelte',
 	framework: 'kit',
@@ -17,5 +17,3 @@ const config = {
 		},
 	},
 }
-
-export default config

--- a/packages/houdini/cmd/init.ts
+++ b/packages/houdini/cmd/init.ts
@@ -141,12 +141,11 @@ const configFile = ({
 
 	return module === 'esm'
 		? // SvelteKit default config
-		  `
-		  /** @type {import('houdini').ConfigFile} */
-		  export default ${configObj}
+		  `/** @type {import('houdini').ConfigFile} */
+export default ${configObj}
 `
 		: // sapper default config
 		  `/** @type {import('houdini').ConfigFile} */
-		  module.exports = ${configObj}
+module.exports = ${configObj}
 `
 }

--- a/packages/houdini/cmd/init.ts
+++ b/packages/houdini/cmd/init.ts
@@ -141,9 +141,16 @@ const configFile = ({
 
 	return module === 'esm'
 		? // SvelteKit default config
-		  `export default ${configObj}
+		  `
+		  /** @type {import('houdini').ConfigFile} */
+		  const config = ${configObj}
+
+		  export default config;
 `
 		: // sapper default config
-		  `module.exports = ${configObj}
+		  `/** @type {import('houdini').ConfigFile} */
+		  const config = ${configObj}
+
+		  module.exports = config;
 `
 }

--- a/packages/houdini/cmd/init.ts
+++ b/packages/houdini/cmd/init.ts
@@ -143,14 +143,10 @@ const configFile = ({
 		? // SvelteKit default config
 		  `
 		  /** @type {import('houdini').ConfigFile} */
-		  const config = ${configObj}
-
-		  export default config;
+		  export default ${configObj}
 `
 		: // sapper default config
 		  `/** @type {import('houdini').ConfigFile} */
-		  const config = ${configObj}
-
-		  module.exports = config;
+		  module.exports = ${configObj}
 `
 }

--- a/packages/houdini/cmd/types.ts
+++ b/packages/houdini/cmd/types.ts
@@ -1,4 +1,7 @@
 import type * as graphql from 'graphql'
+
+export type { ConfigFile } from 'houdini-common'
+
 export * from '../runtime/types'
 
 // the result of collecting documents from source code

--- a/packages/houdini/runtime/types.ts
+++ b/packages/houdini/runtime/types.ts
@@ -1,5 +1,7 @@
 import type { Config } from 'houdini-common'
 
+export type { ConfigFile } from 'houdini-common'
+
 export type Fragment<_Result> = {
 	readonly shape?: _Result
 }

--- a/packages/houdini/runtime/types.ts
+++ b/packages/houdini/runtime/types.ts
@@ -1,7 +1,5 @@
 import type { Config } from 'houdini-common'
 
-export type { ConfigFile } from 'houdini-common'
-
 export type Fragment<_Result> = {
 	readonly shape?: _Result
 }


### PR DESCRIPTION
Hey,

just a small enhancement to enable typable configs. It's quite nice to have some confidence while changing configs and comes with basically zero cost...

Btw, thanks for your work - its great to expand the svelte-way of tackle modern frontend-problems to the graphql-client! :)