### PR TITLE
Feat: onLoad Hook

### DIFF
--- a/packages/houdini-preprocess/src/transforms/query.test.ts
+++ b/packages/houdini-preprocess/src/transforms/query.test.ts
@@ -507,10 +507,16 @@ test('onLoad hook', async function () {
 			export async function onLoad(){
 			   return this.redirect(302, "/test")
 			}
+
+			export function TestQueryVariables(page) {
+				return {
+					test: true
+				}
+			}
 		</script>
 		<script>
 			const { data } = query(graphql\`
-				query TestQuery {
+				query TestQuery($test: Boolean!) {
 					viewer {
 						id
 					}
@@ -530,13 +536,29 @@ test('onLoad hook', async function () {
 		    return this.redirect(302, "/test");
 		}
 
+		export function TestQueryVariables(page) {
+		    return {
+		        test: true
+		    };
+		}
+
 		export async function load(context) {
 		    const _houdini_context = new RequestContext(context);
-		    const _TestQuery_Input = {};
 
 		    await _houdini_context.onLoadHook({
 		        "mode": "sapper",
 		        "onLoadFunction": onLoad
+		    });
+
+		    if (!_houdini_context.continue) {
+		        return _houdini_context.returnValue;
+		    }
+
+		    const _TestQuery_Input = _houdini_context.computeInput({
+		        "config": houdiniConfig,
+		        "mode": "sapper",
+		        "variableFunction": TestQueryVariables,
+		        "artifact": _TestQueryArtifact
 		    });
 
 		    if (!_houdini_context.continue) {

--- a/packages/houdini-preprocess/src/transforms/query.test.ts
+++ b/packages/houdini-preprocess/src/transforms/query.test.ts
@@ -500,75 +500,70 @@ describe('query preprocessor', function () {
 	test.todo('adds arguments to an empty preload')
 })
 
-// test('onLoad hook', async function () {
-// 	const doc = await preprocessorTest(
-// 		`
-// 		<script context="module">
-// 			export async function onLoad(){
-// 			   return this.redirect(302, '/test')
-// 			}
-// 		</script>
-// 		<script>
-// 			const { data } = query(graphql\`
-// 				query TestQuery {
-// 					viewer {
-// 						id
-// 					}
-// 				}
-// 			\`)
-// 		</script>
-// 	`
-// 	)
+test('onLoad hook', async function () {
+	const doc = await preprocessorTest(
+		`
+		<script context="module">
+			export async function onLoad(){
+			   return this.redirect(302, "/test")
+			}
+		</script>
+		<script>
+			const { data } = query(graphql\`
+				query TestQuery {
+					viewer {
+						id
+					}
+				}
+			\`)
+		</script>
+	`
+	)
 
-// 	expect(doc.module?.content).toMatchInlineSnapshot(`
-// 	import { convertKitPayload } from '$houdini';
-// 	import { fetchQuery, RequestContext } from '$houdini';
-// 	import _TestQueryArtifact from '$houdini/artifacts/TestQuery';
-// 	import { houdiniConfig } from '$houdini';
+	expect(doc.module?.content).toMatchInlineSnapshot(`
+		import { convertKitPayload } from "$houdini";
+		import { fetchQuery, RequestContext } from "$houdini";
+		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
+		import { houdiniConfig } from "$houdini";
 
-// 	export async function onLoad() {
-// 		return this.redirect(302, '/test');
-// 	}
+		export async function onLoad() {
+		    return this.redirect(302, "/test");
+		}
 
-// 	export async function load(context) {
-// 		const _houdini_context = new RequestContext(context);
-// 		const _TestQuery_Input = {};
+		export async function load(context) {
+		    const _houdini_context = new RequestContext(context);
+		    const _TestQuery_Input = {};
 
-// 		if (onLoad) {
-// 			const onLoadValue = _houdini_context.onLoadHook({
-// 				mode: 'sapper',
-// 				onLoadFunction: onLoad,
-// 			});
-// 		}
+		    _houdini_context.onLoadHook({
+		        "mode": "sapper",
+		        "onLoadFunction": onLoad
+		    });
 
-// 		if (!_houdini_context.continue) {
-// 			return _houdini_context.returnValue;
-// 		}
+		    if (!_houdini_context.continue) {
+		        return _houdini_context.returnValue;
+		    }
 
-// 		const _TestQuery = await fetchQuery(
-// 			_houdini_context,
-// 			{
-// 				text: _TestQueryArtifact.raw,
-// 				variables: _TestQuery_Input,
-// 			},
-// 			context.session
-// 		);
+		    const _TestQuery = await fetchQuery(_houdini_context, {
+		        "text": _TestQueryArtifact.raw,
+		        "variables": _TestQuery_Input
+		    }, context.session);
 
-// 		if (!_TestQuery.data) {
-// 			_houdini_context.graphqlErrors(_TestQuery);
-// 			return _houdini_context.returnValue;
-// 		}
+		    if (!_TestQuery.data) {
+		        _houdini_context.graphqlErrors(_TestQuery);
+		        return _houdini_context.returnValue;
+		    }
 
-// 		return {
-// 			props: {
-// 				_TestQuery: _TestQuery,
-// 				_TestQuery_Input: _TestQuery_Input,
-// 			},
-// 		};
-// 	}
+		    return {
+		        props: {
+		            ..._houdini_context.returnValue,
+		            _TestQuery: _TestQuery,
+		            _TestQuery_Input: _TestQuery_Input
+		        }
+		    };
+		}
 
-// 	export function preload(page, session) {
-// 		return convertKitPayload(this, load, page, session);
-// 	}
-//   `)
-// })
+		export function preload(page, session) {
+		    return convertKitPayload(this, load, page, session);
+		}
+  `)
+})

--- a/packages/houdini-preprocess/src/transforms/query.test.ts
+++ b/packages/houdini-preprocess/src/transforms/query.test.ts
@@ -534,7 +534,7 @@ test('onLoad hook', async function () {
 		    const _houdini_context = new RequestContext(context);
 		    const _TestQuery_Input = {};
 
-		    _houdini_context.onLoadHook({
+		    await _houdini_context.onLoadHook({
 		        "mode": "sapper",
 		        "onLoadFunction": onLoad
 		    });

--- a/packages/houdini-preprocess/src/transforms/query.test.ts
+++ b/packages/houdini-preprocess/src/transforms/query.test.ts
@@ -499,3 +499,76 @@ describe('query preprocessor', function () {
 
 	test.todo('adds arguments to an empty preload')
 })
+
+// test('onLoad hook', async function () {
+// 	const doc = await preprocessorTest(
+// 		`
+// 		<script context="module">
+// 			export async function onLoad(){
+// 			   return this.redirect(302, '/test')
+// 			}
+// 		</script>
+// 		<script>
+// 			const { data } = query(graphql\`
+// 				query TestQuery {
+// 					viewer {
+// 						id
+// 					}
+// 				}
+// 			\`)
+// 		</script>
+// 	`
+// 	)
+
+// 	expect(doc.module?.content).toMatchInlineSnapshot(`
+// 	import { convertKitPayload } from '$houdini';
+// 	import { fetchQuery, RequestContext } from '$houdini';
+// 	import _TestQueryArtifact from '$houdini/artifacts/TestQuery';
+// 	import { houdiniConfig } from '$houdini';
+
+// 	export async function onLoad() {
+// 		return this.redirect(302, '/test');
+// 	}
+
+// 	export async function load(context) {
+// 		const _houdini_context = new RequestContext(context);
+// 		const _TestQuery_Input = {};
+
+// 		if (onLoad) {
+// 			const onLoadValue = _houdini_context.onLoadHook({
+// 				mode: 'sapper',
+// 				onLoadFunction: onLoad,
+// 			});
+// 		}
+
+// 		if (!_houdini_context.continue) {
+// 			return _houdini_context.returnValue;
+// 		}
+
+// 		const _TestQuery = await fetchQuery(
+// 			_houdini_context,
+// 			{
+// 				text: _TestQueryArtifact.raw,
+// 				variables: _TestQuery_Input,
+// 			},
+// 			context.session
+// 		);
+
+// 		if (!_TestQuery.data) {
+// 			_houdini_context.graphqlErrors(_TestQuery);
+// 			return _houdini_context.returnValue;
+// 		}
+
+// 		return {
+// 			props: {
+// 				_TestQuery: _TestQuery,
+// 				_TestQuery_Input: _TestQuery_Input,
+// 			},
+// 		};
+// 	}
+
+// 	export function preload(page, session) {
+// 		return convertKitPayload(this, load, page, session);
+// 	}
+//   `)
+// })

--- a/packages/houdini-preprocess/src/transforms/query.test.ts
+++ b/packages/houdini-preprocess/src/transforms/query.test.ts
@@ -569,6 +569,7 @@ test('onLoad hook', async function () {
 		    }
 
 		    const _TestQuery = await fetchQuery(_houdini_context, {
+		        "hash": _TestQueryArtifact.hash,
 		        "text": _TestQueryArtifact.raw,
 		        "variables": _TestQuery_Input
 		    }, context.session);

--- a/packages/houdini-preprocess/src/transforms/query.ts
+++ b/packages/houdini-preprocess/src/transforms/query.ts
@@ -416,20 +416,22 @@ function addKitLoad(config: Config, body: Statement[], queries: EmbeddedGraphqlD
 			]),
 			onloadDefinition &&
 				AST.expressionStatement(
-					AST.callExpression(
-						AST.memberExpression(requestContext, AST.identifier('onLoadHook')),
-						[
-							AST.objectExpression([
-								AST.objectProperty(
-									AST.literal('mode'),
-									AST.stringLiteral(config.framework)
-								),
-								AST.objectProperty(
-									AST.literal('onLoadFunction'),
-									AST.identifier('onLoad')
-								),
-							]),
-						]
+					AST.awaitExpression(
+						AST.callExpression(
+							AST.memberExpression(requestContext, AST.identifier('onLoadHook')),
+							[
+								AST.objectExpression([
+									AST.objectProperty(
+										AST.literal('mode'),
+										AST.stringLiteral(config.framework)
+									),
+									AST.objectProperty(
+										AST.literal('onLoadFunction'),
+										AST.identifier('onLoad')
+									),
+								]),
+							]
+						)
 					)
 				),
 			// if we ran into a problem computing the variables
@@ -498,31 +500,24 @@ function addKitLoad(config: Config, body: Statement[], queries: EmbeddedGraphqlD
 		)
 
 		if (onloadDefinition) {
-			// add the field to the return value of preload
+			// add the returnValue of the onLoad Hook to the return value of pre(load)
 			propsValue.properties.push(
 				// @ts-ignore
 				AST.spreadProperty(
 					AST.memberExpression(requestContext, AST.identifier('returnValue'))
-				),
-				AST.objectProperty(AST.identifier(preloadKey), AST.identifier(preloadKey)),
-				// @ts-ignore
-				AST.objectProperty(
-					AST.identifier(variableIdentifier),
-					AST.identifier(variableIdentifier)
-				)
-			)
-		} else {
-			// add the field to the return value of preload
-			propsValue.properties.push(
-				// @ts-ignore
-				AST.objectProperty(AST.identifier(preloadKey), AST.identifier(preloadKey)),
-				// @ts-ignore
-				AST.objectProperty(
-					AST.identifier(variableIdentifier),
-					AST.identifier(variableIdentifier)
 				)
 			)
 		}
+		// add the field to the return value of preload
+		propsValue.properties.push(
+			// @ts-ignore
+			AST.objectProperty(AST.identifier(preloadKey), AST.identifier(preloadKey)),
+			// @ts-ignore
+			AST.objectProperty(
+				AST.identifier(variableIdentifier),
+				AST.identifier(variableIdentifier)
+			)
+		)
 	}
 }
 

--- a/packages/houdini-preprocess/src/transforms/query.ts
+++ b/packages/houdini-preprocess/src/transforms/query.ts
@@ -415,33 +415,22 @@ function addKitLoad(config: Config, body: Statement[], queries: EmbeddedGraphqlD
 				),
 			]),
 			onloadDefinition &&
-				AST.ifStatement(
-					AST.identifier('onLoad'),
-					AST.blockStatement([
-						AST.variableDeclaration('const', [
-							AST.variableDeclarator(
-								AST.identifier('onLoadValue'),
-								AST.callExpression(
-									AST.memberExpression(
-										requestContext,
-										AST.identifier('onLoadHook')
-									),
-									[
-										AST.objectExpression([
-											AST.objectProperty(
-												AST.literal('mode'),
-												AST.stringLiteral(config.framework)
-											),
-											AST.objectProperty(
-												AST.literal('onLoadFunction'),
-												AST.identifier('onLoad')
-											),
-										]),
-									]
-								)
-							),
-						]),
-					])
+				AST.expressionStatement(
+					AST.callExpression(
+						AST.memberExpression(requestContext, AST.identifier('onLoadHook')),
+						[
+							AST.objectExpression([
+								AST.objectProperty(
+									AST.literal('mode'),
+									AST.stringLiteral(config.framework)
+								),
+								AST.objectProperty(
+									AST.literal('onLoadFunction'),
+									AST.identifier('onLoad')
+								),
+							]),
+						]
+					)
 				),
 			// if we ran into a problem computing the variables
 			AST.ifStatement(
@@ -508,16 +497,32 @@ function addKitLoad(config: Config, body: Statement[], queries: EmbeddedGraphqlD
 			)
 		)
 
-		// add the field to the return value of preload
-		propsValue.properties.push(
-			// @ts-ignore
-			AST.objectProperty(AST.identifier(preloadKey), AST.identifier(preloadKey)),
-			// @ts-ignore
-			AST.objectProperty(
-				AST.identifier(variableIdentifier),
-				AST.identifier(variableIdentifier)
+		if (onloadDefinition) {
+			// add the field to the return value of preload
+			propsValue.properties.push(
+				// @ts-ignore
+				AST.spreadProperty(
+					AST.memberExpression(requestContext, AST.identifier('returnValue'))
+				),
+				AST.objectProperty(AST.identifier(preloadKey), AST.identifier(preloadKey)),
+				// @ts-ignore
+				AST.objectProperty(
+					AST.identifier(variableIdentifier),
+					AST.identifier(variableIdentifier)
+				)
 			)
-		)
+		} else {
+			// add the field to the return value of preload
+			propsValue.properties.push(
+				// @ts-ignore
+				AST.objectProperty(AST.identifier(preloadKey), AST.identifier(preloadKey)),
+				// @ts-ignore
+				AST.objectProperty(
+					AST.identifier(variableIdentifier),
+					AST.identifier(variableIdentifier)
+				)
+			)
+		}
 	}
 }
 

--- a/packages/houdini/runtime/network.ts
+++ b/packages/houdini/runtime/network.ts
@@ -235,7 +235,7 @@ export class RequestContext {
 
 	// This hook fires before executing any queries, it allows to redirect/error based on session state for example
 	// It also allows to return custom props that should be returned from the corresponding load function.
-	onLoadHook({
+	async onLoadHook({
 		mode,
 		onLoadFunction,
 	}: {
@@ -245,8 +245,12 @@ export class RequestContext {
 		// call the onLoad function to match the framework
 		let result =
 			mode === 'kit'
-				? (onLoadFunction as KitLoad).call(this, this.context)
-				: (onLoadFunction as SapperLoad).call(this, this.context.page, this.context.session)
+				? await (onLoadFunction as KitLoad).call(this, this.context)
+				: await (onLoadFunction as SapperLoad).call(
+						this,
+						this.context.page,
+						this.context.session
+				  )
 
 		// If the result is null or undefined, or the result isn't an object return early
 		if (result == null || typeof result !== 'object') {

--- a/packages/houdini/runtime/network.ts
+++ b/packages/houdini/runtime/network.ts
@@ -252,6 +252,10 @@ export class RequestContext {
 						this.context.session
 				  )
 
+		// If the returnValue is already set through this.error or this.redirect return early
+		if (this.continue) {
+			return
+		}
 		// If the result is null or undefined, or the result isn't an object return early
 		if (result == null || typeof result !== 'object') {
 			return

--- a/packages/houdini/runtime/network.ts
+++ b/packages/houdini/runtime/network.ts
@@ -253,7 +253,7 @@ export class RequestContext {
 				  )
 
 		// If the returnValue is already set through this.error or this.redirect return early
-		if (this.continue) {
+		if (!this.continue) {
 			return
 		}
 		// If the result is null or undefined, or the result isn't an object return early

--- a/packages/houdini/runtime/network.ts
+++ b/packages/houdini/runtime/network.ts
@@ -233,6 +233,14 @@ export class RequestContext {
 		return this.error(500, 'Encountered invalid response: ' + JSON.stringify(payload))
 	}
 
+	onLoadHook({ mode, onLoadFunction }: any) {
+		if (mode === 'kit') {
+			onLoadFunction.call(this, this.context)
+		} else {
+			onLoadFunction.call(this, this.context.page, this.context.session)
+		}
+	}
+
 	// compute the inputs for an operation should reflect the framework's conventions.
 	// in sapper, this means preparing a `this` for the function. for kit, we can just pass
 	// the context

--- a/yarn.lock
+++ b/yarn.lock
@@ -5704,8 +5704,8 @@ __metadata:
     apollo-server: ^2.24.0
     graphql: 15.5.0
     graphql-relay: ^0.8.0
-    houdini: ^0.10.0-alpha.13
-    houdini-preprocess: ^0.10.0-alpha.13
+    houdini: ^0.10.0
+    houdini-preprocess: ^0.10.0
     subscriptions-transport-ws: ^0.9.18
     svelte: ^3.38.2
     svelte-preprocess: ^4.0.0
@@ -6716,7 +6716,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"houdini-common@^0.10.0-alpha.8, houdini-common@workspace:packages/houdini-common":
+"houdini-common@^0.10.0, houdini-common@workspace:packages/houdini-common":
   version: 0.0.0-use.local
   resolution: "houdini-common@workspace:packages/houdini-common"
   dependencies:
@@ -6761,7 +6761,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"houdini-preprocess@^0.10.0-alpha.13, houdini-preprocess@workspace:packages/houdini-preprocess":
+"houdini-preprocess@^0.10.0, houdini-preprocess@workspace:packages/houdini-preprocess":
   version: 0.0.0-use.local
   resolution: "houdini-preprocess@workspace:packages/houdini-preprocess"
   dependencies:
@@ -6775,8 +6775,8 @@ __metadata:
     babylon: ^7.0.0-beta.47
     estree-walker: ^2.0.2
     graphql: 15.5.0
-    houdini: ^0.10.0-alpha.13
-    houdini-common: ^0.10.0-alpha.8
+    houdini: ^0.10.0
+    houdini-common: ^0.10.0
     jest: ^26.6.3
     mkdirp: ^1.0.4
     prettier: "*"
@@ -6787,7 +6787,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"houdini@^0.10.0-alpha.13, houdini@workspace:packages/houdini":
+"houdini@^0.10.0, houdini@workspace:packages/houdini":
   version: 0.0.0-use.local
   resolution: "houdini@workspace:packages/houdini"
   dependencies:
@@ -6808,7 +6808,7 @@ __metadata:
     estree-walker: ^2.0.2
     glob: ^7.1.6
     graphql: ^15.5.0
-    houdini-common: ^0.10.0-alpha.8
+    houdini-common: ^0.10.0
     inquirer: ^7.3.3
     jest: ^26.6.3
     mkdirp: ^1.0.4


### PR DESCRIPTION
Closes #147

This implements the `onLoad` hook, it get's the same args as the variable functions and can return `this.error` `this.redirect` etc.

Also if you return some object from the function it get's added to the return of `load`.

e.g.

```svelte
  <script context="module">
     // It has access to the same arguments and this.error this.redirect as the variable functions
      export function onLoad({page, session}){

       if(!session.authenticated){
            return this.redirect(302, '/login')
       }

         return {  hello: "world" }
      } 
 </script>

 <script>
     export let hello
 </script>
```