### PR TITLE
fix leaking cache, while ssr

### DIFF
--- a/example/src/routes/__layout.svelte
+++ b/example/src/routes/__layout.svelte
@@ -1,12 +1,19 @@
 <script context="module">
 	import env from '../environment'
 	import { setEnvironment, setCache, getCache } from '$houdini'
+	import { browser } from '$app/env'
 
 	setEnvironment(env)
 </script>
 
 <script>
 	setCache()
+	const cache = getCache()
+
+	if (browser) {
+		//@ts-ignore
+		window.cache = cache
+	}
 </script>
 
 <svelte:head>

--- a/example/src/routes/__layout.svelte
+++ b/example/src/routes/__layout.svelte
@@ -1,15 +1,12 @@
 <script context="module">
 	import env from '../environment'
-	import { setEnvironment } from '$houdini'
-	import cache from '$houdini/runtime/cache'
-	import { browser } from '$app/env'
-
-	if (browser) {
-		// @ts-ignore
-		window.cache = cache
-	}
+	import { setEnvironment, setCache, getCache } from '$houdini'
 
 	setEnvironment(env)
+</script>
+
+<script>
+	setCache()
 </script>
 
 <svelte:head>

--- a/packages/houdini/cmd/generators/runtime/copyRuntime.test.ts
+++ b/packages/houdini/cmd/generators/runtime/copyRuntime.test.ts
@@ -28,9 +28,13 @@ test('cache index runtime imports config file - commonjs', async function () {
 	expect(parsedQuery).toMatchInlineSnapshot(`
 		var config = require('../../../../../config.cjs');
 		Object.defineProperty(exports, "__esModule", { value: true });
+		exports.createCache = void 0;
 		var cache_1 = require("./cache");
-		// @ts-ignore: config will be defined by the generator
-		exports.default = new cache_1.Cache(config || {});
+		function createCache() {
+		    // @ts-ignore: config will be defined by the generator
+		    return new cache_1.Cache(config || {});
+		}
+		exports.createCache = createCache;
 	`)
 })
 
@@ -53,7 +57,9 @@ test('cache index runtime imports config file - kit', async function () {
 	expect(parsedQuery).toMatchInlineSnapshot(`
 		import config from "../../../config.cjs"
 		import { Cache } from './cache';
-		// @ts-ignore: config will be defined by the generator
-		export default new Cache(config || {});
+		export function createCache() {
+		    // @ts-ignore: config will be defined by the generator
+		    return new Cache(config || {});
+		}
 	`)
 })

--- a/packages/houdini/runtime/cache/index.ts
+++ b/packages/houdini/runtime/cache/index.ts
@@ -1,8 +1,5 @@
 import { Cache } from './cache'
 
-// @ts-ignore: config will be defined by the generator
-export default new Cache(config || {})
-
 export function createCache() {
 	// @ts-ignore: config will be defined by the generator
 	return new Cache(config || {})

--- a/packages/houdini/runtime/cache/index.ts
+++ b/packages/houdini/runtime/cache/index.ts
@@ -2,3 +2,8 @@ import { Cache } from './cache'
 
 // @ts-ignore: config will be defined by the generator
 export default new Cache(config || {})
+
+export function createCache() {
+	// @ts-ignore: config will be defined by the generator
+	return new Cache(config || {})
+}

--- a/packages/houdini/runtime/context.ts
+++ b/packages/houdini/runtime/context.ts
@@ -4,5 +4,15 @@ import type { Cache } from './cache/cache'
 
 export const setVariables = (vars: () => {}) => setContext('variables', vars)
 export const getVariables = (): (() => {}) => getContext('variables') || (() => ({}))
-export const getCache = () => getContext<Cache>('__houdini__cache__')
+export const getCache = () => {
+	const cache = getContext<Cache>('__houdini__cache__')
+
+	if (!cache) {
+		throw new Error(
+			'Please invoke setCache() from $houdini inside of your entry point instance script e.g. (__layout.svelte, App.svelte)'
+		)
+	}
+
+	return cache
+}
 export const setCache = () => setContext('__houdini__cache__', createCache())

--- a/packages/houdini/runtime/context.ts
+++ b/packages/houdini/runtime/context.ts
@@ -1,4 +1,8 @@
 import { setContext, getContext } from 'svelte'
+import { createCache } from './cache'
+import type { Cache } from './cache/cache'
 
 export const setVariables = (vars: () => {}) => setContext('variables', vars)
 export const getVariables = (): (() => {}) => getContext('variables') || (() => ({}))
+export const getCache = () => getContext<Cache>('__houdini__cache__')
+export const setCache = () => setContext('__houdini__cache__', createCache())

--- a/packages/houdini/runtime/fragment.ts
+++ b/packages/houdini/runtime/fragment.ts
@@ -3,8 +3,7 @@ import { readable, Readable } from 'svelte/store'
 import { onMount } from 'svelte'
 // locals
 import type { Fragment, FragmentArtifact, GraphQLTagResult, SubscriptionSpec } from './types'
-import cache from './cache'
-import { getVariables } from './context'
+import { getCache, getVariables } from './context'
 
 // fragment returns the requested data from the reference
 export function fragment<_Fragment extends Fragment<any>>(
@@ -15,6 +14,8 @@ export function fragment<_Fragment extends Fragment<any>>(
 	if (fragment.kind !== 'HoudiniFragment') {
 		throw new Error('getFragment can only take fragment documents')
 	}
+
+	const cache = getCache()
 
 	// we might get re-exported values nested under default
 

--- a/packages/houdini/runtime/fragment.ts
+++ b/packages/houdini/runtime/fragment.ts
@@ -3,19 +3,23 @@ import { readable, Readable } from 'svelte/store'
 import { onMount } from 'svelte'
 // locals
 import type { Fragment, FragmentArtifact, GraphQLTagResult, SubscriptionSpec } from './types'
+import type { Cache } from './cache/cache'
 import { getCache, getVariables } from './context'
 
 // fragment returns the requested data from the reference
 export function fragment<_Fragment extends Fragment<any>>(
 	fragment: GraphQLTagResult,
-	initialValue: _Fragment
+	initialValue: _Fragment,
+	cache?: Cache
 ): Readable<_Fragment['shape']> {
 	// make sure we got a query document
 	if (fragment.kind !== 'HoudiniFragment') {
 		throw new Error('getFragment can only take fragment documents')
 	}
 
-	const cache = getCache()
+	if (!cache) {
+		cache = getCache()
+	}
 
 	// we might get re-exported values nested under default
 
@@ -46,12 +50,12 @@ export function fragment<_Fragment extends Fragment<any>>(
 		// when the component mounts
 		onMount(() => {
 			// stay up to date
-			cache.subscribe(subscriptionSpec, queryVariables())
+			cache!.subscribe(subscriptionSpec, queryVariables())
 		})
 		// the function used to clean up the store
 		return () => {
 			// if we subscribed to something we'll need to clean up
-			cache.unsubscribe(
+			cache!.unsubscribe(
 				{
 					rootType: artifact.rootType,
 					parentID,

--- a/packages/houdini/runtime/fragment.ts
+++ b/packages/houdini/runtime/fragment.ts
@@ -47,12 +47,12 @@ export function fragment<_Fragment extends Fragment<any>>(
 		// when the component mounts
 		onMount(() => {
 			// stay up to date
-			cache!.subscribe(subscriptionSpec, queryVariables())
+			cache.subscribe(subscriptionSpec, queryVariables())
 		})
 		// the function used to clean up the store
 		return () => {
 			// if we subscribed to something we'll need to clean up
-			cache!.unsubscribe(
+			cache.unsubscribe(
 				{
 					rootType: artifact.rootType,
 					parentID,

--- a/packages/houdini/runtime/fragment.ts
+++ b/packages/houdini/runtime/fragment.ts
@@ -2,24 +2,21 @@
 import { readable, Readable } from 'svelte/store'
 import { onMount } from 'svelte'
 // locals
-import type { Fragment, FragmentArtifact, GraphQLTagResult, SubscriptionSpec } from './types'
-import type { Cache } from './cache/cache'
+import type { Fragment, FragmentArtifact, GraphQLTagResult } from './types'
 import { getCache, getVariables } from './context'
 
 // fragment returns the requested data from the reference
 export function fragment<_Fragment extends Fragment<any>>(
 	fragment: GraphQLTagResult,
-	initialValue: _Fragment,
-	cache?: Cache
+	initialValue: _Fragment
 ): Readable<_Fragment['shape']> {
 	// make sure we got a query document
 	if (fragment.kind !== 'HoudiniFragment') {
 		throw new Error('getFragment can only take fragment documents')
 	}
 
-	if (!cache) {
-		cache = getCache()
-	}
+	// Get the cache from the context
+	const cache = getCache()
 
 	// we might get re-exported values nested under default
 

--- a/packages/houdini/runtime/index.ts
+++ b/packages/houdini/runtime/index.ts
@@ -4,6 +4,7 @@ export * from './network'
 export * from './types'
 
 export { query, routeQuery, componentQuery } from './query'
+export { setCache, getCache } from './context'
 export { mutation } from './mutation'
 export { fragment } from './fragment'
 export { subscription } from './subscription'

--- a/packages/houdini/runtime/mutation.ts
+++ b/packages/houdini/runtime/mutation.ts
@@ -3,8 +3,7 @@ import type { Config } from 'houdini-common'
 // locals
 import { executeQuery } from './network'
 import { Operation, GraphQLTagResult, MutationArtifact } from './types'
-import cache from './cache'
-import { getVariables } from './context'
+import { getCache, getVariables } from './context'
 import { marshalInputs, unmarshalSelection } from './scalars'
 
 // @ts-ignore: this file will get generated and does not exist in the source code
@@ -21,6 +20,8 @@ export function mutation<_Mutation extends Operation<any, any>>(
 	}
 
 	// we might get re-exported values nested under default
+
+	const cache = getCache()
 
 	// @ts-ignore: typing esm/cjs interop is hard
 	const artifact: MutationArtifact = document.artifact.default || document.artifact

--- a/packages/houdini/runtime/pagination.ts
+++ b/packages/houdini/runtime/pagination.ts
@@ -36,10 +36,11 @@ export function paginatedQuery<_Query extends Operation<any, any>>(
 		throw new Error('paginatedQuery must be passed a query with @paginate.')
 	}
 
+	// Get the cache from the context
 	const cache = getCache()
 
 	// pass the artifact to the base query operation
-	const { data, loading, ...restOfQueryResponse } = query(document, cache)
+	const { data, loading, ...restOfQueryResponse } = query(document)
 
 	return {
 		data,
@@ -68,10 +69,11 @@ export function paginatedFragment<_Fragment extends Fragment<any>>(
 		throw new Error('paginatedFragment must be passed a fragment with @paginate')
 	}
 
+	// Get the cache from the context
 	const cache = getCache()
 
 	// pass the inputs to the normal fragment function
-	const data = fragment(document, initialValue, cache)
+	const data = fragment(document, initialValue)
 
 	// @ts-ignore: typing esm/cjs interop is hard
 	const fragmentArtifact: FragmentArtifact = document.artifact.default || document.artifact

--- a/packages/houdini/runtime/pagination.ts
+++ b/packages/houdini/runtime/pagination.ts
@@ -36,10 +36,10 @@ export function paginatedQuery<_Query extends Operation<any, any>>(
 		throw new Error('paginatedQuery must be passed a query with @paginate.')
 	}
 
-	// pass the artifact to the base query operation
-	const { data, loading, ...restOfQueryResponse } = query(document)
-
 	const cache = getCache()
+
+	// pass the artifact to the base query operation
+	const { data, loading, ...restOfQueryResponse } = query(document, cache)
 
 	return {
 		data,
@@ -68,10 +68,10 @@ export function paginatedFragment<_Fragment extends Fragment<any>>(
 		throw new Error('paginatedFragment must be passed a fragment with @paginate')
 	}
 
-	// pass the inputs to the normal fragment function
-	const data = fragment(document, initialValue)
-
 	const cache = getCache()
+
+	// pass the inputs to the normal fragment function
+	const data = fragment(document, initialValue, cache)
 
 	// @ts-ignore: typing esm/cjs interop is hard
 	const fragmentArtifact: FragmentArtifact = document.artifact.default || document.artifact

--- a/packages/houdini/runtime/query.ts
+++ b/packages/houdini/runtime/query.ts
@@ -3,6 +3,7 @@ import { Readable, writable, readable } from 'svelte/store'
 import { onDestroy, onMount } from 'svelte'
 import type { Config } from 'houdini-common'
 // locals
+import type { Cache } from './cache/cache'
 import { Operation, GraphQLTagResult, SubscriptionSpec, QueryArtifact } from './types'
 import { getCache, setVariables } from './context'
 import { executeQuery, RequestPayload } from './network'
@@ -12,15 +13,17 @@ import { marshalInputs, unmarshalSelection } from './scalars'
 import { getSession, goTo } from './adapter.mjs'
 
 export function query<_Query extends Operation<any, any>>(
-	document: GraphQLTagResult
+	document: GraphQLTagResult,
+	cache?: Cache
 ): QueryResponse<_Query['result'], _Query['input']> {
 	// make sure we got a query document
 	if (document.kind !== 'HoudiniQuery') {
 		throw new Error('query() must be passed a query document')
 	}
 
-	const cache = getCache()
-
+	if (!cache) {
+		cache = getCache()
+	}
 	// we might get re-exported values nested under default
 
 	// @ts-ignore: typing esm/cjs interop is hard
@@ -56,7 +59,7 @@ export function query<_Query extends Operation<any, any>>(
 		// if we were given data on mount
 		if (initialValue) {
 			// update the cache with the data that we just ran into
-			cache.write({
+			cache!.write({
 				selection: artifact.selection,
 				data: initialValue,
 				variables,
@@ -64,7 +67,7 @@ export function query<_Query extends Operation<any, any>>(
 
 			// stay up to date
 			if (subscriptionSpec) {
-				cache.subscribe(subscriptionSpec, variables)
+				cache!.subscribe(subscriptionSpec, variables)
 			}
 		}
 	})
@@ -72,7 +75,7 @@ export function query<_Query extends Operation<any, any>>(
 	// the function used to clean up the store
 	onDestroy(() => {
 		subscriptionSpec = null
-		cache.unsubscribe(
+		cache!.unsubscribe(
 			{
 				rootType: artifact.rootType,
 				selection: artifact.selection,
@@ -87,7 +90,7 @@ export function query<_Query extends Operation<any, any>>(
 
 	function writeData(newData: RequestPayload<_Query['result']>, newVariables: _Query['input']) {
 		// write the data we received
-		cache.write({
+		cache!.write({
 			selection: artifact.selection,
 			data: newData.data,
 			variables: newVariables,
@@ -96,8 +99,8 @@ export function query<_Query extends Operation<any, any>>(
 		// if the variables changed we need to unsubscribe from the old fields and
 		// listen to the new ones
 		if (subscriptionSpec && JSON.stringify(variables) !== JSON.stringify(newVariables)) {
-			cache.unsubscribe(subscriptionSpec, variables)
-			cache.subscribe(subscriptionSpec, newVariables)
+			cache!.unsubscribe(subscriptionSpec, variables)
+			cache!.subscribe(subscriptionSpec, newVariables)
 		}
 
 		// update the local store

--- a/packages/houdini/runtime/query.ts
+++ b/packages/houdini/runtime/query.ts
@@ -4,8 +4,7 @@ import { onDestroy, onMount } from 'svelte'
 import type { Config } from 'houdini-common'
 // locals
 import { Operation, GraphQLTagResult, SubscriptionSpec, QueryArtifact } from './types'
-import cache from './cache'
-import { setVariables } from './context'
+import { getCache, setVariables } from './context'
 import { executeQuery, RequestPayload } from './network'
 import { marshalInputs, unmarshalSelection } from './scalars'
 
@@ -20,12 +19,14 @@ export function query<_Query extends Operation<any, any>>(
 		throw new Error('query() must be passed a query document')
 	}
 
+	const cache = getCache()
+
 	// we might get re-exported values nested under default
 
 	// @ts-ignore: typing esm/cjs interop is hard
 	const artifact: QueryArtifact = document.artifact.default || document.artifact
-	// @ts-ignore: typing esm/cjs interop is hard
-	const config: Config = document.config.default || document.config
+
+	const config: Config = cache._config
 
 	// a query is never 'loading'
 	const loading = writable(false)

--- a/packages/houdini/runtime/subscription.ts
+++ b/packages/houdini/runtime/subscription.ts
@@ -5,8 +5,8 @@ import type { Config } from 'houdini-common'
 // locals
 import { Operation, GraphQLTagResult, SubscriptionArtifact } from './types'
 import { getEnvironment } from './network'
-import cache from './cache'
 import { marshalInputs, unmarshalSelection } from './scalars'
+import { getCache } from './context'
 
 // subscription holds open a live connection to the server. it returns a store
 // containing the requested data. Houdini will also update the cache with any
@@ -21,6 +21,8 @@ export function subscription<_Subscription extends Operation<any, any>>(
 	if (document.kind !== 'HoudiniSubscription') {
 		throw new Error('subscription() must be passed a subscription document')
 	}
+
+	const cache = getCache()
 
 	// we might get re-exported values nested under default
 


### PR DESCRIPTION
Currently the cache leaks through requests, which could lead to huge cache size and maybe some data leaks? 

You can reproduce the issue if you import the cache inside `hooks` `handle` and log `cache._data` it' always is filled.

 I think this PR will  also help implementing the fetch-policy since data is always really cached on the client side.

This approach uses sveltes get/setContext which creates a new Cache for every request and keeps only one cache on the client side. 
This would introduce a new setCache() function which should be invoked in the entry point file e.g. `__layout.svelte` or `App.svelte`. 

Maybe there is a better naming for setCache(), it's a bit weird for me needing to invoke `setEnvironment` in `context module` and `setCache` in `instance script` - Also this is a breaking change and needs proper documentation or probably some kind of error message if the context is not found