### PR TITLE
Clear style tag content when parsing

### DIFF
--- a/packages/houdini-common/src/parse.test.ts
+++ b/packages/houdini-common/src/parse.test.ts
@@ -406,6 +406,44 @@ describe('parser tests', () => {
 		checkScriptBounds(doc, result)
 	})
 
+	test("styling tag parse errors don't fail (postcss support)", async () => {
+		const doc = `<script lang="ts">
+		const example = object({});
+	</script>
+	<style>
+		.test { 
+			&_title {
+				width: 500px;
+				@media (max-width: 500px) {
+					width: auto;
+				}
+				body.is_dark & {
+					color: white;
+				}
+			}
+			img {
+				display: block;
+			}
+		}
+	</style>
+
+	<div>hello</div>
+	`
+
+		// parse the string
+		const result = await parseFile(doc)
+
+		expect(result.instance?.content).toMatchInlineSnapshot(`const example = object({});`)
+		expect(result.instance?.start).toMatchInlineSnapshot(`0`)
+		expect(result.instance?.end).toMatchInlineSnapshot(`58`)
+
+		expect(result.module?.content).toMatchInlineSnapshot(`undefined`)
+		expect(result.module?.start).toMatchInlineSnapshot(`undefined`)
+		expect(result.module?.end).toMatchInlineSnapshot(`undefined`)
+
+		checkScriptBounds(doc, result)
+	})
+
 	test('empty object in script', async () => {
 		const doc = `<script lang="ts">
 		const example = object({});

--- a/packages/houdini-common/src/parse.ts
+++ b/packages/houdini-common/src/parse.ts
@@ -19,6 +19,11 @@ export async function parseFile(str: string): Promise<ParsedSvelteFile> {
 					code: input.replace(/\S/g, ' '),
 				}
 			},
+			style({ content: input }) {
+				return {
+					code: input.replace(/\S/g, ' '),
+				}
+			},
 		},
 	])
 	// parse the result to find the bounds


### PR DESCRIPTION
This PR fixes #159 by clearing the style contents before running the parser. 

This really only delays a larger problem, however. A very similar issue will happen if a user ever has a non-typescript `<script>` tag that babel can't parse. Ideally we would be able to hook into the defined list of preprocessors and run those which would normalize the javascript tags. I'm not really sure how to best pull that off so I think this is a fine patch for now. 