### PR TITLE
Address houdini generate -p errors if schema file doesn't exist

### DIFF
--- a/packages/houdini-common/src/config.ts
+++ b/packages/houdini-common/src/config.ts
@@ -88,6 +88,9 @@ export class Config {
 
 			// interpret the schema path as relative to cwd
 			const localSchemaPath = path.resolve(process.cwd(), schemaPath)
+			if (!fs.existsSync(localSchemaPath)) {
+				throw new Error(`Schema file does not exist! Create it using houdini generate -p`)
+			}
 
 			// if the schema points to an sdl file
 			if (localSchemaPath.endsWith('gql') || localSchemaPath.endsWith('graphql')) {

--- a/packages/houdini-common/src/config.ts
+++ b/packages/houdini-common/src/config.ts
@@ -392,18 +392,11 @@ export class Config {
 		throw new Error('Could not find list name from fragment: ' + fragmentName)
 	}
 }
-// a place to store the current configuration
-let _config: Config
 
-// get the project's current configuration
-export async function getConfig(): Promise<Config> {
-	if (_config) {
-		return _config
-	}
+const DEFAULT_CONFIG_PATH = path.join(process.cwd(), 'houdini.config.js')
 
-	// load the config file
-	const configPath = path.join(process.cwd(), 'houdini.config.js')
-
+// helper function to load the config file
+export async function loadConfigFile(configPath: string = DEFAULT_CONFIG_PATH): Promise<any> {
 	// on windows, we need to prepend the right protocol before we
 	// can import from an absolute path
 	let importPath = configPath
@@ -415,8 +408,21 @@ export async function getConfig(): Promise<Config> {
 
 	// if this is wrapped in a default, use it
 	const config = imported.default || imported
+	return config
+}
+
+// a place to store the current configuration
+let _config: Config
+
+// get the project's current configuration
+export async function getConfig(): Promise<Config> {
+	if (_config) {
+		return _config
+	}
 
 	// add the filepath and save the result
+	const configPath = DEFAULT_CONFIG_PATH
+	const config = await loadConfigFile(configPath)
 	_config = new Config({
 		...config,
 		filepath: configPath,

--- a/packages/houdini/cmd/main.ts
+++ b/packages/houdini/cmd/main.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // external imports
-import { getConfig } from 'houdini-common'
+import { getConfig, loadConfigFile } from 'houdini-common'
 import { Command } from 'commander'
 import path from 'path'
 // local imports
@@ -21,14 +21,12 @@ program
 	.action(
 		async (args: { pullSchema: boolean; persistOutput?: string } = { pullSchema: false }) => {
 			// grab the config file
-			const config = await getConfig()
+			let config
 
 			try {
-				if (args.persistOutput) {
-					config.persistedQueryPath = args.persistOutput
-				}
 				// Pull the newest schema if the flag is set
 				if (args.pullSchema) {
+					config = await loadConfigFile()
 					// Check if apiUrl is set in config
 					if (!config.apiUrl) {
 						throw new Error(
@@ -38,14 +36,19 @@ program
 					// The target path -> current working directory by default. Should we allow passing custom paths?
 					const targetPath = process.cwd()
 					// Write the schema
-					const schema = await writeSchema(
+					await writeSchema(
 						config.apiUrl,
 						config.schemaPath
 							? config.schemaPath
 							: path.resolve(targetPath, 'schema.json')
 					)
-					// Set the newly written schema into the config
-					config.schema = schema
+					console.log(`Pulled latest schema from ${config.apiUrl}`)
+				}
+
+				// Load config
+				config = await getConfig()
+				if (args.persistOutput) {
+					config.persistedQueryPath = args.persistOutput
 				}
 				await generate(config)
 			} catch (e) {


### PR DESCRIPTION
Bug fixes for #162

```
benj@MacBook ~/projects/houdini/example
fix/issue-162* $ ls schema
index.cjs

benj@MacBook ~/projects/houdini/example
fix/issue-162* $ yarn generate
Error: Schema file does not exist! Create it using houdini generate -p
    at new Config (file:///Users/benj/projects/houdini/packages/houdini/build/cmd.js:688:23)
    at file:///Users/benj/projects/houdini/packages/houdini/build/cmd.js:1067:31
    at step (file:///Users/benj/projects/houdini/packages/houdini/build/cmd.js:346:23)
    at Object.next (file:///Users/benj/projects/houdini/packages/houdini/build/cmd.js:327:53)
    at fulfilled (file:///Users/benj/projects/houdini/packages/houdini/build/cmd.js:317:58)

benj@MacBook ~/projects/houdini/example
fix/issue-162* $ yarn generate -p
Pulled latest schema from http://localhost:4000/graphql
ItemEntry_item
UncompleteItem
ItemUpdate
AllItems
AddItem
NewItem
CompleteItem
DeleteItem
```