### PR TITLE
Fix error when marshaling/unmarshaling enums

### DIFF
--- a/packages/houdini/runtime/scalars.test.ts
+++ b/packages/houdini/runtime/scalars.test.ts
@@ -97,6 +97,7 @@ const artifact: QueryArtifact = {
 		fields: {
 			date: 'NestedDate',
 			booleanValue: 'Boolean',
+			enumValue: 'EnumValue',
 		},
 		types: {
 			NestedDate: {
@@ -258,6 +259,25 @@ describe('marshal inputs', function () {
 			date: undefined,
 		})
 	})
+
+	test('enums', function () {
+		// compute the inputs
+		const inputs = ctx.computeInput({
+			config,
+			mode: 'kit',
+			artifact,
+			variableFunction() {
+				return {
+					enumValue: 'ValueA',
+				}
+			},
+		})
+
+		// make sure we got the expected value
+		expect(inputs).toEqual({
+			enumValue: 'ValueA',
+		})
+	})
 })
 
 describe('unmarshal selection', function () {
@@ -404,6 +424,23 @@ describe('unmarshal selection', function () {
 
 		expect(unmarshalSelection(config, selection, data)).toEqual({
 			rootBool: true,
+		})
+	})
+
+	test('enums', function () {
+		const data = {
+			enumValue: 'Hello',
+		}
+
+		const selection = {
+			enumValue: {
+				type: 'EnumValue',
+				keyRaw: 'enumValue',
+			},
+		}
+
+		expect(unmarshalSelection(config, selection, data)).toEqual({
+			enumValue: 'Hello',
 		})
 	})
 })

--- a/packages/houdini/runtime/scalars.test.ts
+++ b/packages/houdini/runtime/scalars.test.ts
@@ -103,6 +103,7 @@ const artifact: QueryArtifact = {
 			NestedDate: {
 				date: 'DateTime',
 				nested: 'NestedDate',
+				enumValue: 'EnumValue',
 			},
 		},
 	},
@@ -129,6 +130,7 @@ describe('marshal inputs', function () {
 								date: date2,
 								nested: {
 									date: date3,
+									enumValue: 'asdf',
 								},
 							},
 						},
@@ -146,6 +148,7 @@ describe('marshal inputs', function () {
 						date: date2.getTime(),
 						nested: {
 							date: date3.getTime(),
+							enumValue: 'asdf',
 						},
 					},
 				},
@@ -276,6 +279,25 @@ describe('marshal inputs', function () {
 		// make sure we got the expected value
 		expect(inputs).toEqual({
 			enumValue: 'ValueA',
+		})
+	})
+
+	test('list of enums', function () {
+		// compute the inputs
+		const inputs = ctx.computeInput({
+			config,
+			mode: 'kit',
+			artifact,
+			variableFunction() {
+				return {
+					enumValue: ['ValueA', 'ValueB'],
+				}
+			},
+		})
+
+		// make sure we got the expected value
+		expect(inputs).toEqual({
+			enumValue: ['ValueA', 'ValueB'],
 		})
 	})
 })
@@ -441,6 +463,23 @@ describe('unmarshal selection', function () {
 
 		expect(unmarshalSelection(config, selection, data)).toEqual({
 			enumValue: 'Hello',
+		})
+	})
+
+	test('list of enums', function () {
+		const data = {
+			enumValue: ['Hello', 'World'],
+		}
+
+		const selection = {
+			enumValue: {
+				type: 'EnumValue',
+				keyRaw: 'enumValue',
+			},
+		}
+
+		expect(unmarshalSelection(config, selection, data)).toEqual({
+			enumValue: ['Hello', 'World'],
 		})
 	})
 })

--- a/packages/houdini/runtime/scalars.ts
+++ b/packages/houdini/runtime/scalars.ts
@@ -39,10 +39,10 @@ export function marshalInputs<T>({
 	return Object.fromEntries(
 		Object.entries(input as {}).map(([fieldName, value]) => {
 			// look up the type for the field
-			const type = fields[fieldName]
+			const type = fields?.[fieldName]
 			// if we don't have type information for this field, just use it directly
 			// it's most likely a non-custom scalars or enums
-			if (!type) {
+			if (!type || !artifact.input!.types[type]) {
 				return [fieldName, value]
 			}
 
@@ -88,17 +88,7 @@ export function unmarshalSelection(
 				return [fieldName, value]
 			}
 
-			// is the type something that requires marshaling
-			if (config.scalars?.[type]?.marshal) {
-				return [fieldName, config.scalars[type].unmarshal(value)]
-			}
-
-			// if the type doesn't require marshaling and isn't a referenced type
-			// if the type is a scalar that doesn't require marshaling
-			if (isScalar(config, type)) {
-				return [fieldName, value]
-			}
-
+			// if there is a sub selection, walk down the selection
 			if (fields) {
 				return [
 					fieldName,
@@ -107,7 +97,14 @@ export function unmarshalSelection(
 				]
 			}
 
-			return []
+			// is the type something that requires marshaling
+			if (config.scalars?.[type]?.marshal) {
+				return [fieldName, config.scalars[type].unmarshal(value)]
+			}
+
+			// if the type doesn't require marshaling and isn't a referenced type
+			// then the type is a scalar that doesn't require marshaling
+			return [fieldName, value]
 		})
 	)
 }

--- a/packages/houdini/runtime/scalars.ts
+++ b/packages/houdini/runtime/scalars.ts
@@ -42,7 +42,7 @@ export function marshalInputs<T>({
 			const type = fields?.[fieldName]
 			// if we don't have type information for this field, just use it directly
 			// it's most likely a non-custom scalars or enums
-			if (!type || !artifact.input!.types[type]) {
+			if (!type) {
 				return [fieldName, value]
 			}
 
@@ -52,7 +52,7 @@ export function marshalInputs<T>({
 			}
 
 			// if the type doesn't require marshaling and isn't a referenced type
-			if (isScalar(config, type)) {
+			if (isScalar(config, type) || !artifact.input!.types[type]) {
 				return [fieldName, value]
 			}
 


### PR DESCRIPTION
This PR fixes #166, a problem with the marshaling and unmarshaling logic which would destroy enum values. 