### PR TITLE
Add Pull headers arg and call generate from init 

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ for help setting one up. Once you have a project and want to add houdini, execut
 npx houdini init
 ```
 
+> Note, this will send a request to your API to download your schema definition. If you need 
+> headers to authenticate this request, you can pass them in with the `--pull-header` 
+> flag (abbreviated `-ph`). For example, 
+> `npx houdini init -ph Authorization="Bearer MyToken"`. 
+> You will also need to provide the same flag to `generate` when using the 
+> `--pull-schema` flag.
+
 This will create a few necessary files, as well as pull down a json representation of
 your API's schema. Next, generate your runtime:
 

--- a/README.md
+++ b/README.md
@@ -90,25 +90,19 @@ npm install --save-dev houdini houdini-preprocess
 
 Adding houdini to an existing project can easily be done with the provided command-line tool.
 If you don't already have an existing app, visit [this link](https://kit.svelte.dev/docs)
-for help setting one up. Once you have a project and want to add houdini, execute the following command:
+for help setting one up. Once you have a project and want to add houdini, execute the following command which will create a few necessary files, as well as pull down a json
+representation of your API's schema.
 
 ```sh
 npx houdini init
 ```
 
-> Note, this will send a request to your API to download your schema definition. If you need 
+> This will send a request to your API to download your schema definition. If you need 
 > headers to authenticate this request, you can pass them in with the `--pull-header` 
 > flag (abbreviated `-ph`). For example, 
 > `npx houdini init -ph Authorization="Bearer MyToken"`. 
 > You will also need to provide the same flag to `generate` when using the 
 > `--pull-schema` flag.
-
-This will create a few necessary files, as well as pull down a json representation of
-your API's schema. Next, generate your runtime:
-
-```sh
-npx houdini generate
-```
 
 Finally, follow the steps appropriate for your framework.
 

--- a/packages/houdini/cmd/init.ts
+++ b/packages/houdini/cmd/init.ts
@@ -1,8 +1,9 @@
 import path from 'path'
 import inquirer from 'inquirer'
 import fs from 'fs/promises'
-import { Config } from 'houdini-common'
+import { Config, getConfig } from 'houdini-common'
 import { writeSchema } from './utils/writeSchema'
+import generate from './generate'
 
 // the init command is responsible for scaffolding a few files
 // as well as pulling down the initial schema representation
@@ -96,7 +97,16 @@ export default async (_path: string | undefined, args: { pullHeader?: string[] }
 		fs.writeFile(environmentPath, networkFile(answers.url)),
 	])
 
-	console.log('Welcome to houdini!')
+	// generate an empty runtime
+	console.log('Creating necessary files...')
+
+	// make sure we don't log anything else
+	const config = await getConfig()
+	config.quiet = true
+	await generate(config)
+
+	// we're done!
+	console.log('Welcome to Houdini!')
 }
 
 const networkFile = (url: string) => `import { Environment } from '$houdini'

--- a/packages/houdini/cmd/init.ts
+++ b/packages/houdini/cmd/init.ts
@@ -6,7 +6,7 @@ import { writeSchema } from './utils/writeSchema'
 
 // the init command is responsible for scaffolding a few files
 // as well as pulling down the initial schema representation
-export default async (_path: string | undefined) => {
+export default async (_path: string | undefined, args: { pullHeader?: string[] }) => {
 	// we need to collect some information from the user before we
 	// can continue
 	let answers = await inquirer.prompt([
@@ -79,7 +79,7 @@ export default async (_path: string | undefined) => {
 
 	await Promise.all([
 		// Get the schema from the url and write it to file
-		writeSchema(answers.url, path.join(targetPath, answers.schemaPath)),
+		writeSchema(answers.url, path.join(targetPath, answers.schemaPath), args?.pullHeader),
 
 		// write the config file
 		fs.writeFile(

--- a/packages/houdini/cmd/main.ts
+++ b/packages/houdini/cmd/main.ts
@@ -20,7 +20,7 @@ program
 	.option('-po, --persist-output [outputPath]', 'persist queries to a queryMap file')
 	.option(
 		'-ph, --pull-header <headers...>',
-		'headers to use when pulling your schema. Should be passed as KEY=VALUE'
+		'header to use when pulling your schema. Should be passed as KEY=VALUE'
 	)
 	.action(
 		async (
@@ -49,7 +49,8 @@ program
 						config.apiUrl,
 						config.schemaPath
 							? config.schemaPath
-							: path.resolve(targetPath, 'schema.json')
+							: path.resolve(targetPath, 'schema.json'),
+						args.pullHeader
 					)
 					console.log(`Pulled latest schema from ${config.apiUrl}`)
 				}
@@ -69,11 +70,12 @@ program
 // register the init command
 program
 	.command('init')
+	.arguments('[path]')
 	.usage('[path] [options]')
 	.description('initialize a new houdini project')
 	.option(
 		'-ph, --pull-header <headers...>',
-		'headers to use when pulling your schema. Should be passed as KEY=VALUE'
+		'header to use when pulling your schema. Should be passed as KEY=VALUE'
 	)
 	.action(init)
 


### PR DESCRIPTION
This PR does three things:

- adds the `--pull-header` argument to `init` and `generate` allowing users to specify headers to use when pulling the schema 
- `init` now calls `generate` at the end so the user gets their initial runtime
- fix #170