### PR TITLE
Nested error logging on generate command

### DIFF
--- a/packages/houdini/cmd/main.ts
+++ b/packages/houdini/cmd/main.ts
@@ -4,6 +4,7 @@
 import { getConfig, readConfigFile } from 'houdini-common'
 import { Command } from 'commander'
 import path from 'path'
+import util from 'util'
 // local imports
 import generate from './generate'
 import init from './init'
@@ -62,7 +63,7 @@ program
 				}
 				await generate(config)
 			} catch (e) {
-				console.error(e)
+				console.error(util.inspect(e, { showHidden: false, depth: null, colors: true }))
 			}
 		}
 	)


### PR DESCRIPTION
If generate error has nested objects, log their contents

Before
![image](https://user-images.githubusercontent.com/22242264/131204963-268ec59b-ffc6-4827-824e-da7ea54bd444.png)

After
![image](https://user-images.githubusercontent.com/22242264/131205071-7d7ad590-ffa5-4ac1-9f5d-5778f371c085.png)
