### PR TITLE
Check for duplicate selections in generate command

### DIFF
--- a/packages/houdini/cmd/generate.ts
+++ b/packages/houdini/cmd/generate.ts
@@ -38,6 +38,7 @@ export const runPipeline = async (config: Config, docs: CollectedGraphQLDocument
 			validators.typeCheck,
 			transforms.typename,
 			validators.uniqueNames,
+			validators.uniqueSelections,
 			validators.noIDAlias,
 			transforms.paginate, // must go before fragment variables
 			transforms.fragmentVariables,

--- a/packages/houdini/cmd/validators/index.ts
+++ b/packages/houdini/cmd/validators/index.ts
@@ -1,3 +1,4 @@
 export { default as typeCheck } from './typeCheck'
 export { default as uniqueNames } from './uniqueNames'
+export { default as uniqueSelections } from './uniqueSelections'
 export { default as noIDAlias } from './noIDAlias'

--- a/packages/houdini/cmd/validators/uniqueSelections.test.ts
+++ b/packages/houdini/cmd/validators/uniqueSelections.test.ts
@@ -1,0 +1,95 @@
+// locals
+import { pipelineTest } from '../testUtils'
+import '../../../../jest.setup'
+import { CollectedGraphQLDocument, HoudiniError } from '../types'
+
+const table: Row[] = [
+	{
+		title: 'top level duplicates',
+		pass: false,
+		documents: [
+			`
+                query QueryA {
+                    version
+                    version
+                }
+            `,
+			`
+                query QueryB {
+                    user {
+                        id
+                    }
+                    user {
+                        firstName
+                    }
+                }
+            `,
+		],
+	},
+	{
+		title: 'nested duplicates',
+		pass: false,
+		documents: [
+			`
+                query QueryA {
+                    user {
+                        id
+                        id
+                    }
+                }
+            `,
+			`
+                query QueryB {
+                    user {
+                        firstName
+                        firstName
+                    }
+                }
+            `,
+		],
+	},
+	{
+		title: 'positive case',
+		pass: true,
+		documents: [
+			`
+                query QueryA {
+                    version
+                    user {
+                        id
+                        firstName
+                    }
+                }
+            `,
+			`
+                query QueryB {
+                    version
+                    user {
+                        id
+                        firstName
+                    }
+                }
+            `,
+		],
+	},
+]
+
+type Row =
+	| {
+			title: string
+			pass: true
+			documents: string[]
+			check?: (docs: CollectedGraphQLDocument[]) => void
+	  }
+	| {
+			title: string
+			pass: false
+			documents: string[]
+			check?: (result: HoudiniError | HoudiniError[]) => void
+	  }
+
+// run the tests
+for (const { title, pass, documents, check } of table) {
+	// run the pipeline over the documents
+	pipelineTest(title, documents, pass, check)
+}

--- a/packages/houdini/cmd/validators/uniqueSelections.ts
+++ b/packages/houdini/cmd/validators/uniqueSelections.ts
@@ -1,0 +1,79 @@
+// externals
+import { Config } from 'houdini-common'
+import { OperationDefinitionNode } from 'graphql'
+// locals
+import { CollectedGraphQLDocument, HoudiniInfoError } from '../types'
+
+type IRecurseDuplicates = {
+	path: string
+	count: number
+}
+export function recurseDuplicates(
+	node: OperationDefinitionNode,
+	currentPath: string[] = [],
+	acc: IRecurseDuplicates[] = []
+): IRecurseDuplicates[] {
+	const selections = node.selectionSet?.selections || []
+	if (selections.length === 0) {
+		// if no selections under node, return acc
+		return acc
+	}
+
+	// check if current node has duplicates
+	const selectionCount: Record<string, number> = {}
+	const childrenDuplicates = selections
+		.map((s) => {
+			// @ts-ignore - "alias" and "name" are supposed to be valid properties
+			const fieldName = s.alias?.value || s.name.value
+			selectionCount[fieldName] = (selectionCount[fieldName] || 0) + 1
+			return recurseDuplicates(s as any, [...currentPath, fieldName])
+		})
+		.flat()
+
+	// if current node has duplicates, update acc
+	for (let key in selectionCount) {
+		if (selectionCount[key] > 1) {
+			acc.push({
+				path: [...currentPath, key].join('.'),
+				count: selectionCount[key],
+			})
+		}
+	}
+
+	return [...acc, ...childrenDuplicates]
+}
+
+// verifies that there are no duplicate field selections in a node
+export default async function uniqueSelections(
+	config: Config,
+	docs: CollectedGraphQLDocument[]
+): Promise<void> {
+	const operationsWithDuplicates = docs
+		.map((doc) => {
+			return (doc.originalDocument.definitions as OperationDefinitionNode[])
+				.map((def) => {
+					return {
+						operationName: def.name?.value,
+						duplicates: recurseDuplicates(def),
+					}
+				})
+				.flat()
+		})
+		.flat()
+		.filter((d) => d.duplicates.length > 0)
+
+	const errors: HoudiniInfoError[] = operationsWithDuplicates.map(
+		({ operationName, duplicates }) => ({
+			message: `Duplicate selections encountered in ${operationName}`,
+			description: duplicates.map((d) => `${d.path} has ${d.count} duplicates`),
+		})
+	)
+
+	// if we got errors
+	if (errors.length > 0) {
+		throw errors
+	}
+
+	// we're done here
+	return
+}

--- a/packages/houdini/cmd/validators/uniqueSelections.ts
+++ b/packages/houdini/cmd/validators/uniqueSelections.ts
@@ -22,9 +22,12 @@ export function recurseDuplicates(
 	// check if current node has duplicates
 	const selectionCount: Record<string, number> = {}
 	const childrenDuplicates = selections
-		.map((s) => {
-			// @ts-ignore - "alias" and "name" are supposed to be valid properties
-			const fieldName = s.alias?.value || s.name.value
+		.map((s: any) => {
+			// "alias" and "name" are supposed to be valid properties
+			const fieldName: string = s.alias?.value || s.name?.value
+			if (!fieldName) {
+				return []
+			}
 			selectionCount[fieldName] = (selectionCount[fieldName] || 0) + 1
 			return recurseDuplicates(s as any, [...currentPath, fieldName])
 		})


### PR DESCRIPTION
Aims to partially address #158

Queries w/ duplicate selections (top-level & nested)

![image](https://user-images.githubusercontent.com/22242264/131240534-6eb7fc77-cc1f-49a3-bb4c-12363df92832.png)

Output produced when running `houdini generate`

![image](https://user-images.githubusercontent.com/22242264/131240505-20d32331-f61c-4dd2-8bda-551465a350d7.png)