### PR TITLE
List operations can be performed on lists of responses

### DIFF
--- a/packages/houdini/runtime/cache/cache.ts
+++ b/packages/houdini/runtime/cache/cache.ts
@@ -685,43 +685,45 @@ export class Cache {
 					}
 				}
 
-				// only insert an object into a list if we're adding an object with fields
-				if (
-					operation.action === 'insert' &&
-					value instanceof Object &&
-					!Array.isArray(value) &&
-					fields &&
-					operation.list
-				) {
-					this.list(operation.list, parentID)
-						.when(operation.when)
-						.addToList(fields, value, variables, operation.position || 'last')
-				}
-
-				// only insert an object into a list if we're adding an object with fields
-				else if (
-					operation.action === 'remove' &&
-					value instanceof Object &&
-					!Array.isArray(value) &&
-					fields &&
-					operation.list
-				) {
-					this.list(operation.list, parentID)
-						.when(operation.when)
-						.remove(value, variables)
-				}
-
-				// delete the operation if we have to
-				else if (operation.action === 'delete' && operation.type) {
-					if (typeof value !== 'string') {
-						throw new Error('Cannot delete a record with a non-string ID')
+				// there could be a list of elements to perform the operation on
+				const targets = Array.isArray(value) ? value : [value]
+				for (const target of targets) {
+					// only insert an object into a list if we're adding an object with fields
+					if (
+						operation.action === 'insert' &&
+						target instanceof Object &&
+						fields &&
+						operation.list
+					) {
+						this.list(operation.list, parentID)
+							.when(operation.when)
+							.addToList(fields, target, variables, operation.position || 'last')
 					}
 
-					const targetID = this.id(operation.type, value)
-					if (!targetID) {
-						continue
+					// only insert an object into a list if we're adding an object with fields
+					else if (
+						operation.action === 'remove' &&
+						target instanceof Object &&
+						fields &&
+						operation.list
+					) {
+						this.list(operation.list, parentID)
+							.when(operation.when)
+							.remove(target, variables)
 					}
-					this.delete(operation.type, targetID, variables)
+
+					// delete the operation if we have to
+					else if (operation.action === 'delete' && operation.type) {
+						if (typeof target !== 'string') {
+							throw new Error('Cannot delete a record with a non-string ID')
+						}
+
+						const targetID = this.id(operation.type, target)
+						if (!targetID) {
+							continue
+						}
+						this.delete(operation.type, targetID, variables)
+					}
 				}
 			}
 		}

--- a/packages/houdini/runtime/cache/tests/list.test.ts
+++ b/packages/houdini/runtime/cache/tests/list.test.ts
@@ -1484,6 +1484,96 @@ test('append operation', function () {
 	expect([...cache.list('All_Users', cache.id('User', '1')!)]).toHaveLength(1)
 })
 
+test('append from list', function () {
+	// instantiate a cache
+	const cache = new Cache(config)
+
+	// create a list we will add to
+	cache.write({
+		selection: {
+			viewer: {
+				type: 'User',
+				keyRaw: 'viewer',
+				fields: {
+					id: {
+						type: 'ID',
+						keyRaw: 'id',
+					},
+				},
+			},
+		},
+		data: {
+			viewer: {
+				id: '1',
+			},
+		},
+	})
+
+	// subscribe to the data to register the list
+	cache.subscribe(
+		{
+			rootType: 'User',
+			selection: {
+				friends: {
+					type: 'User',
+					keyRaw: 'friends',
+					list: {
+						name: 'All_Users',
+						connection: false,
+						type: 'User',
+					},
+					fields: {
+						id: {
+							type: 'ID',
+							keyRaw: 'id',
+						},
+						firstName: {
+							type: 'String',
+							keyRaw: 'firstName',
+						},
+					},
+				},
+			},
+			parentID: cache.id('User', '1')!,
+			set: jest.fn(),
+		},
+		{}
+	)
+
+	// write some data to a different location with a new user
+	// that should be added to the list
+	cache.write({
+		selection: {
+			newUser: {
+				type: 'User',
+				keyRaw: 'newUser',
+				operations: [
+					{
+						action: 'insert',
+						list: 'All_Users',
+						parentID: {
+							kind: 'String',
+							value: cache.id('User', '1')!,
+						},
+					},
+				],
+				fields: {
+					id: {
+						type: 'ID',
+						keyRaw: 'id',
+					},
+				},
+			},
+		},
+		data: {
+			newUser: [{ id: '3' }, { id: '4' }],
+		},
+	})
+
+	// make sure we just added to the list
+	expect([...cache.list('All_Users', cache.id('User', '1')!)]).toHaveLength(2)
+})
+
 test('append when operation', function () {
 	// instantiate a cache
 	const cache = new Cache(config)
@@ -1913,6 +2003,114 @@ test('remove operation', function () {
 	expect([...cache.list('All_Users', cache.id('User', '1')!)]).toHaveLength(0)
 })
 
+test('remove operation from list', function () {
+	// instantiate a cache
+	const cache = new Cache(config)
+
+	// create a list we will add to
+	cache.write({
+		selection: {
+			viewer: {
+				type: 'User',
+				keyRaw: 'viewer',
+				fields: {
+					id: {
+						type: 'ID',
+						keyRaw: 'id',
+					},
+					friends: {
+						type: 'User',
+						keyRaw: 'friends',
+						fields: {
+							id: {
+								type: 'ID',
+								keyRaw: 'id',
+							},
+							firstName: {
+								type: 'String',
+								keyRaw: 'firstName',
+							},
+						},
+					},
+				},
+			},
+		},
+		data: {
+			viewer: {
+				id: '1',
+				friends: [
+					{ id: '2', firstName: 'jane' },
+					{ id: '3', firstName: 'Alfred' },
+				],
+			},
+		},
+	})
+
+	// subscribe to the data to register the list
+	cache.subscribe(
+		{
+			rootType: 'User',
+			selection: {
+				friends: {
+					type: 'User',
+					keyRaw: 'friends',
+					list: {
+						name: 'All_Users',
+						connection: false,
+						type: 'User',
+					},
+					fields: {
+						id: {
+							type: 'ID',
+							keyRaw: 'id',
+						},
+						firstName: {
+							type: 'String',
+							keyRaw: 'firstName',
+						},
+					},
+				},
+			},
+			parentID: cache.id('User', '1')!,
+			set: jest.fn(),
+		},
+		{}
+	)
+
+	// write some data to a different location with a new user
+	// that should be removed from the operation
+	cache.write({
+		selection: {
+			newUser: {
+				type: 'User',
+				keyRaw: 'newUser',
+				operations: [
+					{
+						action: 'remove',
+						list: 'All_Users',
+						parentID: {
+							kind: 'String',
+							value: cache.id('User', '1')!,
+						},
+					},
+				],
+				fields: {
+					id: {
+						type: 'ID',
+						keyRaw: 'id',
+					},
+				},
+			},
+		},
+		data: {
+			newUser: [{ id: '2' }, { id: '3' }],
+		},
+	})
+
+	// make sure we removed the element from the list
+	expect([...cache.list('All_Users', cache.id('User', '1')!)]).toHaveLength(0)
+})
+
 test('delete operation', function () {
 	// instantiate a cache
 	const cache = new Cache(config)
@@ -2016,6 +2214,115 @@ test('delete operation', function () {
 	expect([...cache.list('All_Users', cache.id('User', '1')!)]).toHaveLength(0)
 
 	expect(cache.internal.getRecord('User:2')).toBeFalsy()
+})
+
+test('delete operation from list', function () {
+	// instantiate a cache
+	const cache = new Cache(config)
+
+	// create a list we will add to
+	cache.write({
+		selection: {
+			viewer: {
+				type: 'User',
+				keyRaw: 'viewer',
+				fields: {
+					id: {
+						type: 'ID',
+						keyRaw: 'id',
+					},
+					friends: {
+						type: 'User',
+						keyRaw: 'friends',
+						fields: {
+							id: {
+								type: 'ID',
+								keyRaw: 'id',
+							},
+							firstName: {
+								type: 'String',
+								keyRaw: 'firstName',
+							},
+						},
+					},
+				},
+			},
+		},
+		data: {
+			viewer: {
+				id: '1',
+				friends: [
+					{ id: '2', firstName: 'jane' },
+					{ id: '3', firstName: 'Alfred' },
+				],
+			},
+		},
+	})
+
+	// subscribe to the data to register the list
+	cache.subscribe(
+		{
+			rootType: 'User',
+			selection: {
+				friends: {
+					type: 'User',
+					keyRaw: 'friends',
+					list: {
+						name: 'All_Users',
+						connection: false,
+						type: 'User',
+					},
+					fields: {
+						id: {
+							type: 'ID',
+							keyRaw: 'id',
+						},
+						firstName: {
+							type: 'String',
+							keyRaw: 'firstName',
+						},
+					},
+				},
+			},
+			parentID: cache.id('User', '1')!,
+			set: jest.fn(),
+		},
+		{}
+	)
+
+	// write some data to a different location with a new user
+	// that should be added to the list
+	cache.write({
+		selection: {
+			deleteUser: {
+				type: 'User',
+				keyRaw: 'deleteUser',
+				fields: {
+					id: {
+						type: 'ID',
+						keyRaw: 'id',
+						operations: [
+							{
+								action: 'delete',
+								type: 'User',
+							},
+						],
+					},
+				},
+			},
+		},
+		data: {
+			deleteUser: {
+				id: ['2', '3'],
+			},
+		},
+	})
+
+	// make sure we removed the element from the list
+	expect([...cache.list('All_Users', cache.id('User', '1')!)]).toHaveLength(0)
+
+	expect(cache.internal.getRecord('User:2')).toBeFalsy()
+	expect(cache.internal.getRecord('User:3')).toBeFalsy()
 })
 
 test('disabled linked lists update', function () {


### PR DESCRIPTION
This PR updates the cache's support for operations to include payloads that are lists (ie if the user needs to add/remove/delete multiple entries at once)

fixes #169