### PR TITLE
Prevent cache error without data

### DIFF
--- a/packages/houdini/runtime/cache/cache.ts
+++ b/packages/houdini/runtime/cache/cache.ts
@@ -201,7 +201,7 @@ export class Cache {
 	}
 
 	private computeID(type: string, data: { [key: string]: GraphQLValue }) {
-		return data.id
+		return data?.id
 	}
 
 	private root(): Record {

--- a/packages/houdini/runtime/cache/tests/cache.test.ts
+++ b/packages/houdini/runtime/cache/tests/cache.test.ts
@@ -2046,7 +2046,7 @@ describe('key evaluation', function () {
 	}
 })
 
-test.only('does not fail without data', function () {
+test('computeID does not throw without data', function () {
 	const cache = new Cache(config)
 
 	expect(cache.id('SomeType', undefined)).toEqual(undefined)

--- a/packages/houdini/runtime/cache/tests/cache.test.ts
+++ b/packages/houdini/runtime/cache/tests/cache.test.ts
@@ -2045,3 +2045,9 @@ describe('key evaluation', function () {
 		})
 	}
 })
+
+test.only('does not fail without data', function () {
+	const cache = new Cache(config)
+
+	expect(cache.id('SomeType', undefined)).toEqual(undefined)
+})


### PR DESCRIPTION
Fixes a reference error when a query returned no data (Using `@include` in my case).

<img width="533" alt="image" src="https://user-images.githubusercontent.com/5802656/141148545-d227b518-4707-46aa-8b93-e9e42ca87680.png">
