### PR TITLE
feature: add query data to onload hooks

### DIFF
--- a/packages/houdini-preprocess/src/transforms/query.test.ts
+++ b/packages/houdini-preprocess/src/transforms/query.test.ts
@@ -90,6 +90,150 @@ describe('query preprocessor', function () {
 	`)
 	})
 
+	test('route - preload initial data for multiple queries', async function () {
+		const doc = await preprocessorTest(
+			`
+			<script>
+				const { data: data1 } = query(graphql\`
+					query TestQuery1 {
+						viewer {
+							id
+						}
+					}
+				\`)
+				const { data: data2 } = query(graphql\`
+					query TestQuery2 {
+						viewer {
+							id
+						}
+					}
+				\`)
+			</script>
+		`
+		)
+
+		// make sure we added the right stuff
+		expect(doc.module?.content).toMatchInlineSnapshot(`
+		import { convertKitPayload } from "$houdini";
+		import { fetchQuery, RequestContext } from "$houdini";
+		import _TestQuery2Artifact from "$houdini/artifacts/TestQuery2";
+		import _TestQuery1Artifact from "$houdini/artifacts/TestQuery1";
+		import { houdiniConfig } from "$houdini";
+
+		export async function load(context) {
+		    const _houdini_context = new RequestContext(context);
+		    const _TestQuery2_Input = {};
+
+		    if (!_houdini_context.continue) {
+		        return _houdini_context.returnValue;
+		    }
+
+		    const [_TestQuery2, _TestQuery2_Source] = await fetchQuery({
+		        "context": context,
+		        "artifact": _TestQuery2Artifact,
+		        "variables": _TestQuery2_Input,
+		        "session": context.session
+		    });
+
+		    if (!_TestQuery2.data) {
+		        _houdini_context.graphqlErrors(_TestQuery2);
+		        return _houdini_context.returnValue;
+		    }
+
+		    const _TestQuery1_Input = {};
+
+		    if (!_houdini_context.continue) {
+		        return _houdini_context.returnValue;
+		    }
+
+		    const [_TestQuery1, _TestQuery1_Source] = await fetchQuery({
+		        "context": context,
+		        "artifact": _TestQuery1Artifact,
+		        "variables": _TestQuery1_Input,
+		        "session": context.session
+		    });
+
+		    if (!_TestQuery1.data) {
+		        _houdini_context.graphqlErrors(_TestQuery1);
+		        return _houdini_context.returnValue;
+		    }
+
+		    return {
+		        props: {
+		            _TestQuery1: _TestQuery1,
+		            _TestQuery1_Input: _TestQuery1_Input,
+		            _TestQuery1_Source: _TestQuery1_Source,
+		            _TestQuery2: _TestQuery2,
+		            _TestQuery2_Input: _TestQuery2_Input,
+		            _TestQuery2_Source: _TestQuery2_Source
+		        }
+		    };
+		}
+
+		export function preload(page, session) {
+		    return convertKitPayload(this, load, page, session);
+		}
+	`)
+		expect(doc.instance?.content).toMatchInlineSnapshot(`
+		import { routeQuery, componentQuery, query } from "$houdini";
+		export let _TestQuery2 = undefined;
+		export let _TestQuery2_Input = undefined;
+		export let _TestQuery2_Source = undefined;
+
+		let _TestQuery2_handler = query({
+		    "config": houdiniConfig,
+		    "initialValue": _TestQuery2,
+		    "variables": _TestQuery2_Input,
+		    "kind": "HoudiniQuery",
+		    "artifact": _TestQuery2Artifact,
+		    "source": _TestQuery2_Source
+		});
+
+		export let _TestQuery1 = undefined;
+		export let _TestQuery1_Input = undefined;
+		export let _TestQuery1_Source = undefined;
+
+		let _TestQuery1_handler = query({
+		    "config": houdiniConfig,
+		    "initialValue": _TestQuery1,
+		    "variables": _TestQuery1_Input,
+		    "kind": "HoudiniQuery",
+		    "artifact": _TestQuery1Artifact,
+		    "source": _TestQuery1_Source
+		});
+
+		const {
+		    data: data1
+		} = routeQuery({
+		    queryHandler: _TestQuery1_handler,
+		    config: houdiniConfig,
+		    artifact: _TestQuery1Artifact,
+		    variableFunction: null,
+		    getProps: () => $$props
+		});
+
+		const {
+		    data: data2
+		} = routeQuery({
+		    queryHandler: _TestQuery2_handler,
+		    config: houdiniConfig,
+		    artifact: _TestQuery2Artifact,
+		    variableFunction: null,
+		    getProps: () => $$props
+		});
+
+		$:
+		{
+		    _TestQuery1_handler.onLoad(_TestQuery1, _TestQuery1_Input, _TestQuery1_Source);
+		}
+
+		$:
+		{
+		    _TestQuery2_handler.onLoad(_TestQuery2, _TestQuery2_Input, _TestQuery2_Source);
+		}
+	`)
+	})
+
 	test('preload initial data with variables', async function () {
 		const doc = await preprocessorTest(
 			`
@@ -594,15 +738,6 @@ test('onLoad hook', async function () {
 		export async function load(context) {
 		    const _houdini_context = new RequestContext(context);
 
-		    await _houdini_context.onLoadHook({
-		        "mode": "sapper",
-		        "onLoadFunction": onLoad
-		    });
-
-		    if (!_houdini_context.continue) {
-		        return _houdini_context.returnValue;
-		    }
-
 		    const _TestQuery_Input = _houdini_context.computeInput({
 		        "config": houdiniConfig,
 		        "mode": "sapper",
@@ -626,12 +761,146 @@ test('onLoad hook', async function () {
 		        return _houdini_context.returnValue;
 		    }
 
+		    await _houdini_context.onLoadHook({
+		        "mode": "sapper",
+		        "onLoadFunction": onLoad,
+
+		        "data": {
+		            "TestQuery": _TestQuery.data
+		        }
+		    });
+
+		    if (!_houdini_context.continue) {
+		        return _houdini_context.returnValue;
+		    }
+
 		    return {
 		        props: {
-		            ..._houdini_context.returnValue,
 		            _TestQuery: _TestQuery,
 		            _TestQuery_Input: _TestQuery_Input,
-		            _TestQuery_Source: _TestQuery_Source
+		            _TestQuery_Source: _TestQuery_Source,
+		            ..._houdini_context.returnValue
+		        }
+		    };
+		}
+
+		export function preload(page, session) {
+		    return convertKitPayload(this, load, page, session);
+		}
+	`)
+})
+
+test('onLoad hook - multiple queries', async function () {
+	const doc = await preprocessorTest(
+		`
+		<script context="module">
+			export async function onLoad(){
+			   return this.redirect(302, "/test")
+			}
+
+			export function TestQueryVariables(page) {
+				return {
+					test: true
+				}
+			}
+		</script>
+		<script>
+			const { data: data1 } = query(graphql\`
+				query TestQuery1 {
+					viewer {
+						id
+					}
+				}
+			\`)
+			const { data: data2 } = query(graphql\`
+				query TestQuery2 {
+					viewer {
+						id
+					}
+				}
+			\`)
+		</script>
+	`
+	)
+
+	expect(doc.module?.content).toMatchInlineSnapshot(`
+		import { convertKitPayload } from "$houdini";
+		import { fetchQuery, RequestContext } from "$houdini";
+		import _TestQuery2Artifact from "$houdini/artifacts/TestQuery2";
+		import _TestQuery1Artifact from "$houdini/artifacts/TestQuery1";
+		import { houdiniConfig } from "$houdini";
+
+		export async function onLoad() {
+		    return this.redirect(302, "/test");
+		}
+
+		export function TestQueryVariables(page) {
+		    return {
+		        test: true
+		    };
+		}
+
+		export async function load(context) {
+		    const _houdini_context = new RequestContext(context);
+		    const _TestQuery2_Input = {};
+
+		    if (!_houdini_context.continue) {
+		        return _houdini_context.returnValue;
+		    }
+
+		    const [_TestQuery2, _TestQuery2_Source] = await fetchQuery({
+		        "context": context,
+		        "artifact": _TestQuery2Artifact,
+		        "variables": _TestQuery2_Input,
+		        "session": context.session
+		    });
+
+		    if (!_TestQuery2.data) {
+		        _houdini_context.graphqlErrors(_TestQuery2);
+		        return _houdini_context.returnValue;
+		    }
+
+		    const _TestQuery1_Input = {};
+
+		    if (!_houdini_context.continue) {
+		        return _houdini_context.returnValue;
+		    }
+
+		    const [_TestQuery1, _TestQuery1_Source] = await fetchQuery({
+		        "context": context,
+		        "artifact": _TestQuery1Artifact,
+		        "variables": _TestQuery1_Input,
+		        "session": context.session
+		    });
+
+		    if (!_TestQuery1.data) {
+		        _houdini_context.graphqlErrors(_TestQuery1);
+		        return _houdini_context.returnValue;
+		    }
+
+		    await _houdini_context.onLoadHook({
+		        "mode": "sapper",
+		        "onLoadFunction": onLoad,
+
+		        "data": {
+		            "TestQuery1": _TestQuery1.data,
+		            "TestQuery2": _TestQuery2.data
+		        }
+		    });
+
+		    if (!_houdini_context.continue) {
+		        return _houdini_context.returnValue;
+		    }
+
+		    return {
+		        props: {
+		            _TestQuery1: _TestQuery1,
+		            _TestQuery1_Input: _TestQuery1_Input,
+		            _TestQuery1_Source: _TestQuery1_Source,
+		            _TestQuery2: _TestQuery2,
+		            _TestQuery2_Input: _TestQuery2_Input,
+		            _TestQuery2_Source: _TestQuery2_Source,
+		            ..._houdini_context.returnValue
 		        }
 		    };
 		}

--- a/packages/houdini/runtime/network.ts
+++ b/packages/houdini/runtime/network.ts
@@ -67,6 +67,10 @@ export type FetchContext = {
 	context: Record<string, any>
 }
 
+export type OnLoadContext = FetchContext & {
+	data: Record<string, any>
+}
+
 export type KitLoadResponse = {
 	status?: number
 	error?: Error
@@ -297,18 +301,24 @@ export class RequestContext {
 	async onLoadHook({
 		mode,
 		onLoadFunction,
+		data,
 	}: {
 		mode: 'kit' | 'sapper'
 		onLoadFunction: SapperLoad | KitLoad
+		data: Record<string, any>
 	}) {
 		// call the onLoad function to match the framework
 		let result =
 			mode === 'kit'
-				? await (onLoadFunction as KitLoad).call(this, this.context)
-				: await (onLoadFunction as SapperLoad).call(
+				? await (onLoadFunction as KitOnLoad).call(this, {
+						...this.context,
+						data,
+				  } as OnLoadContext)
+				: await (onLoadFunction as SapperOnLoad).call(
 						this,
 						this.context.page,
-						this.context.session
+						this.context.session,
+						data
 				  )
 
 		// If the returnValue is already set through this.error or this.redirect return early
@@ -358,5 +368,11 @@ type SapperLoad = (
 	page: FetchContext['page'],
 	session: FetchContext['session']
 ) => Record<string, any>
+type SapperOnLoad = (
+	page: FetchContext['page'],
+	session: FetchContext['session'],
+	data: Record<string, any>
+) => Record<string, any>
 
 type KitLoad = (ctx: FetchContext) => Record<string, any>
+type KitOnLoad = (ctx: OnLoadContext) => Record<string, any>

--- a/packages/houdini/runtime/network.ts
+++ b/packages/houdini/runtime/network.ts
@@ -67,7 +67,8 @@ export type FetchContext = {
 	context: Record<string, any>
 }
 
-export type OnLoadContext = FetchContext & {
+export type BeforeLoadContext = FetchContext
+export type AfterLoadContext = FetchContext & {
 	data: Record<string, any>
 }
 
@@ -298,28 +299,47 @@ export class RequestContext {
 
 	// This hook fires before executing any queries, it allows to redirect/error based on session state for example
 	// It also allows to return custom props that should be returned from the corresponding load function.
-	async onLoadHook({
+	async invokeLoadHook({
+		variant,
 		mode,
-		onLoadFunction,
+		hookFn,
 		data,
 	}: {
+		variant: 'before' | 'after'
 		mode: 'kit' | 'sapper'
-		onLoadFunction: SapperLoad | KitLoad
+		hookFn: KitBeforeLoad | KitAfterLoad | SapperBeforeLoad | SapperAfterLoad
 		data: Record<string, any>
 	}) {
 		// call the onLoad function to match the framework
-		let result =
-			mode === 'kit'
-				? await (onLoadFunction as KitOnLoad).call(this, {
-						...this.context,
-						data,
-				  } as OnLoadContext)
-				: await (onLoadFunction as SapperOnLoad).call(
-						this,
-						this.context.page,
-						this.context.session,
-						data
-				  )
+		let hookCall
+		if (mode === 'kit') {
+			if (variant === 'before') {
+				hookCall = (hookFn as KitBeforeLoad).call(this, this.context as BeforeLoadContext)
+			} else {
+				hookCall = (hookFn as KitAfterLoad).call(this, {
+					...this.context,
+					data,
+				} as AfterLoadContext)
+			}
+		} else {
+			// sapper
+			if (variant === 'before') {
+				hookCall = (hookFn as SapperBeforeLoad).call(
+					this,
+					this.context.page,
+					this.context.session
+				)
+			} else {
+				hookCall = (hookFn as SapperAfterLoad).call(
+					this,
+					this.context.page,
+					this.context.session,
+					data
+				)
+			}
+		}
+
+		let result = await hookCall
 
 		// If the returnValue is already set through this.error or this.redirect return early
 		if (!this.continue) {
@@ -343,7 +363,7 @@ export class RequestContext {
 		artifact,
 	}: {
 		mode: 'kit' | 'sapper'
-		variableFunction: SapperLoad | KitLoad
+		variableFunction: SapperBeforeLoad | KitBeforeLoad
 		artifact: QueryArtifact | MutationArtifact | SubscriptionArtifact
 		config: Config
 	}) {
@@ -351,9 +371,9 @@ export class RequestContext {
 		let input =
 			mode === 'kit'
 				? // in kit just pass the context directly
-				  (variableFunction as KitLoad).call(this, this.context)
+				  (variableFunction as KitBeforeLoad).call(this, this.context)
 				: // we are in sapper mode, so we need to prepare the function context
-				  (variableFunction as SapperLoad).call(
+				  (variableFunction as SapperBeforeLoad).call(
 						this,
 						this.context.page,
 						this.context.session
@@ -364,15 +384,15 @@ export class RequestContext {
 	}
 }
 
-type SapperLoad = (
+type SapperBeforeLoad = (
 	page: FetchContext['page'],
 	session: FetchContext['session']
 ) => Record<string, any>
-type SapperOnLoad = (
+type SapperAfterLoad = (
 	page: FetchContext['page'],
 	session: FetchContext['session'],
 	data: Record<string, any>
 ) => Record<string, any>
 
-type KitLoad = (ctx: FetchContext) => Record<string, any>
-type KitOnLoad = (ctx: OnLoadContext) => Record<string, any>
+type KitBeforeLoad = (ctx: BeforeLoadContext) => Record<string, any>
+type KitAfterLoad = (ctx: AfterLoadContext) => Record<string, any>


### PR DESCRIPTION
fixes #202

Makes graphql query result data available to houdini's `onLoad` hook. 
This align's with sveltekit's design, notably allows customizing HTTP responses.

Sveltekit `onLoad` hooks now have a access to a new property on their existing single context argument:

```js
export function onLoad({ data }) {
    const result = data.MyQuery
    ...
}
```

and for sapper, via a new argument:

```js
export function onLoad(page, session, data) {
    const result = data.MyQuery
    ...
}
```


## Update:

Following code review, the `onLoad` is now split into two hooks: `beforeLoad` and `afterLoad`
`beforeLoad` can be considered the same as the legacy `onLoad` hook. `afterLoad` is a new hook with the same call semantics as `beforeLoad`, but with an extra `data` attribute containing query data. It gets invoked after graphql network calls.

```js
export function beforeLoad() {
    ...
}
export function afterLoad({ data }) {
    const result = data.MyQuery
    ...
}
```

call order is now:

```
1. beforeLoad
2. {query}Variables function (once per query)
3. [graphql network calls]
4. afterLoad
```

- [x] spike implementation following discussion in #202 
- [ ] feedback. review with care! I didn't feel familiar with much here so not confident in my choices throughout.
- [ ] update readme 

disclaimers:
* new to this project
* new to graphql
* new to working with ASTs
* little typescript experience

tested "the full stack" on a local project, was able to inspect query results and return a custom http status.