### PR TITLE
Fix isRoute detection in preprocessor

### DIFF
--- a/packages/houdini-preprocess/src/transforms/query.ts
+++ b/packages/houdini-preprocess/src/transforms/query.ts
@@ -24,6 +24,8 @@ const AST = recast.types.builders
 // what this means in practice is that if we see a getQuery(graphql``) in the instance script of a component, we need to hoist
 // it into the module's preload, grab the result and set it as the initial value in the store.
 
+const posixify = (str: string) => str.replace(/\\/g, '/')
+
 export default async function queryProcessor(
 	config: Config,
 	doc: TransformDocument
@@ -37,7 +39,7 @@ export default async function queryProcessor(
 	const isRoute =
 		config.framework !== 'svelte' &&
 		!config.static &&
-		doc.filename.startsWith(path.join(config.projectRoot, 'src', 'routes'))
+		posixify(doc.filename).startsWith(posixify(path.join(config.projectRoot, 'src', 'routes')))
 
 	// figure out the root type
 	const rootType = doc.config.schema.getQueryType()


### PR DESCRIPTION
I've stumbled across the #170 issue again on windows, i've gone ahead and found a simple fix, windows paths always contain back slashes, but the doc.filename forward slashes so to make the detection correct we replace all backlashes with forward slashes.