### PR TITLE
Make result type possibly undefined

### DIFF
--- a/packages/houdini/cmd/generators/typescript/index.ts
+++ b/packages/houdini/cmd/generators/typescript/index.ts
@@ -151,7 +151,12 @@ async function generateOperationTypeDefs(
 					readonlyProperty(
 						AST.tsPropertySignature(
 							AST.stringLiteral('result'),
-							AST.tsTypeAnnotation(AST.tsTypeReference(AST.identifier(shapeTypeName)))
+							AST.tsTypeAnnotation(
+								AST.tsUnionType([
+									AST.tsTypeReference(AST.identifier(shapeTypeName)),
+									AST.tsUndefinedKeyword(),
+								])
+							)
 						)
 					),
 				])

--- a/packages/houdini/cmd/generators/typescript/typescript.test.ts
+++ b/packages/houdini/cmd/generators/typescript/typescript.test.ts
@@ -251,7 +251,7 @@ describe('typescript', function () {
 		).toMatchInlineSnapshot(`
 		export type Query = {
 		    readonly "input": null,
-		    readonly "result": Query$result
+		    readonly "result": Query$result | undefined
 		};
 
 		export type Query$result = {
@@ -285,7 +285,7 @@ describe('typescript', function () {
 		).toMatchInlineSnapshot(`
 		export type Query = {
 		    readonly "input": null,
-		    readonly "result": Query$result
+		    readonly "result": Query$result | undefined
 		};
 
 		export type Query$result = {
@@ -316,7 +316,7 @@ describe('typescript', function () {
 		).toMatchInlineSnapshot(`
 		export type Query = {
 		    readonly "input": Query$input,
-		    readonly "result": Query$result
+		    readonly "result": Query$result | undefined
 		};
 
 		export type Query$result = {
@@ -375,7 +375,7 @@ describe('typescript', function () {
 		).toMatchInlineSnapshot(`
 		export type Mutation = {
 		    readonly "input": Mutation$input,
-		    readonly "result": Mutation$result
+		    readonly "result": Mutation$result | undefined
 		};
 
 		export type Mutation$result = {
@@ -436,7 +436,7 @@ describe('typescript', function () {
 		).toMatchInlineSnapshot(`
 		export type Query = {
 		    readonly "input": Query$input,
-		    readonly "result": Query$result
+		    readonly "result": Query$result | undefined
 		};
 
 		export type Query$result = {
@@ -514,7 +514,7 @@ describe('typescript', function () {
 		).toMatchInlineSnapshot(`
 		export type Query = {
 		    readonly "input": null,
-		    readonly "result": Query$result
+		    readonly "result": Query$result | undefined
 		};
 
 		export type Query$result = {
@@ -558,7 +558,7 @@ describe('typescript', function () {
 		).toMatchInlineSnapshot(`
 		export type Query = {
 		    readonly "input": null,
-		    readonly "result": Query$result
+		    readonly "result": Query$result | undefined
 		};
 
 		export type Query$result = {
@@ -604,7 +604,7 @@ describe('typescript', function () {
 		).toMatchInlineSnapshot(`
 		export type Query = {
 		    readonly "input": null,
-		    readonly "result": Query$result
+		    readonly "result": Query$result | undefined
 		};
 
 		export type Query$result = {
@@ -651,7 +651,7 @@ describe('typescript', function () {
 		).toMatchInlineSnapshot(`
 		export type Query = {
 		    readonly "input": null,
-		    readonly "result": Query$result
+		    readonly "result": Query$result | undefined
 		};
 
 		export type Query$result = {
@@ -702,7 +702,7 @@ describe('typescript', function () {
 		).toMatchInlineSnapshot(`
 		export type Query = {
 		    readonly "input": null,
-		    readonly "result": Query$result
+		    readonly "result": Query$result | undefined
 		};
 
 		export type Query$result = {
@@ -764,7 +764,7 @@ describe('typescript', function () {
 		).toMatchInlineSnapshot(`
 		export type Query = {
 		    readonly "input": null,
-		    readonly "result": Query$result
+		    readonly "result": Query$result | undefined
 		};
 
 		export type Query$result = {
@@ -822,7 +822,7 @@ describe('typescript', function () {
 		).toMatchInlineSnapshot(`
 		export type Query = {
 		    readonly "input": Query$input,
-		    readonly "result": Query$result
+		    readonly "result": Query$result | undefined
 		};
 
 		export type Query$result = {
@@ -864,7 +864,7 @@ describe('typescript', function () {
 		).toMatchInlineSnapshot(`
 		export type Query = {
 		    readonly "input": null,
-		    readonly "result": Query$result
+		    readonly "result": Query$result | undefined
 		};
 
 		export type Query$result = {
@@ -904,7 +904,7 @@ describe('typescript', function () {
 		).toMatchInlineSnapshot(`
 		export type Query = {
 		    readonly "input": null,
-		    readonly "result": Query$result
+		    readonly "result": Query$result | undefined
 		};
 
 		export type Query$result = {


### PR DESCRIPTION
I am always forgetting that `$data` might be `undefined` since the typescript type does not specify it, so i changed the result type to be a union of the old type and `undefined`. I was not too sure if i should put it on the Query type, `$result` type or on the runtime query, mutation, etc. data types